### PR TITLE
Abort if grid_area variable is not on source scrip grid file.

### DIFF
--- a/tools/mapping/gen_mapping_files/runoff_to_ocn/src/map_mod.F90
+++ b/tools/mapping/gen_mapping_files/runoff_to_ocn/src/map_mod.F90
@@ -656,7 +656,12 @@ SUBROUTINE map_gridRead(map, rfilename, ofilename, gridtype, lmake_rSCRIP)
       rcode = nf_inq_varid     (fid,'grid_imask',vid )
       rcode = nf_get_var_int   (fid,vid     ,map%mask_a)
       rcode = nf_inq_varid     (fid,'grid_area',vid )
-      rcode = nf_get_var_double(fid,vid     ,map%area_a)
+      if (rcode.eq.0) then
+         rcode = nf_get_var_double(fid,vid     ,map%area_a)
+      else
+         write(6,*) "ERROR: could not find variable grid_area in source grid input file!"
+         stop
+      end if
 
       map%frac_a = map%mask_a * 1.0_r8
 

--- a/tools/mapping/gen_mapping_files/runoff_to_ocn/src/map_mod.F90
+++ b/tools/mapping/gen_mapping_files/runoff_to_ocn/src/map_mod.F90
@@ -823,7 +823,12 @@ SUBROUTINE map_gridRead(map, rfilename, ofilename, gridtype, lmake_rSCRIP)
    rcode = nf_inq_varid     (fid,'grid_imask',vid )
    rcode = nf_get_var_int   (fid,vid     ,map%mask_b)
    rcode = nf_inq_varid     (fid,'grid_area',vid )
-   rcode = nf_get_var_double(fid,vid     ,map%area_b)
+   if (rcode.eq.0) then
+      rcode = nf_get_var_double(fid,vid     ,map%area_b)
+   else
+      write(6,*) "ERROR: could not find variable grid_area in destination grid input file!"
+      stop
+   end if
 
    map%frac_b = map%mask_b * 1.0_r8
 


### PR DESCRIPTION
Many of our scrip grid files do not have the grid_area
variable. Without this change, the runoff_to_ocn tool was assigning 0
areas to all grid cells, which resulted in 0 mapping weights. This fix
ensures that the tool aborts in this case.
