### PR TITLE
Removed references to DOUT_S_GENERATE_TSERIES XML variable from cesm_…

### DIFF
--- a/scripts/Tools/cesm_postrun_setup
+++ b/scripts/Tools/cesm_postrun_setup
@@ -10,7 +10,6 @@ setenv RUNDIR				`./xmlquery RUNDIR			-value `
 setenv LOGDIR				`./xmlquery LOGDIR			-value `
 setenv DOUT_S				`./xmlquery DOUT_S			-value `
 setenv DOUT_S_ROOT			`./xmlquery DOUT_S_ROOT			-value `
-setenv DOUT_S_GENERATE_TSERIES		`./xmlquery DOUT_S_GENERATE_TSERIES	-value `
 setenv DOUT_S_SAVE_ALL_ON_DISK		`./xmlquery DOUT_S_SAVE_ALL_ON_DISK	-value `
 setenv DOUT_S_SAVE_HISTORY_FILES	`./xmlquery DOUT_S_SAVE_HISTORY_FILES	-value `
 setenv MACH				`./xmlquery MACH			-value `
@@ -75,28 +74,6 @@ if ($DOUT_S == 'TRUE' && $exceeded_max_time == 0) then
   echo "Archiving ccsm output to $DOUT_S_ROOT"
   echo "Calling the short-term archiving script st_archive"
    ./st_archive 
-
-# -------------------------------------------------------------------------
-# Generate time series variable files - currently only working on yellowstone
-# -------------------------------------------------------------------------
-  if ($DOUT_S_GENERATE_TSERIES == 'TRUE') then
-     if ($DOUT_S_SAVE_ALL_ON_DISK == 'TRUE' && $MACH == 'yellowstone') then
-	if ($DOUT_S_SAVE_HISTORY_FILES == 'FALSE') then
-	    echo "*WARNING* successful generation of the variable time series files"
-	    echo "will delete all the time slice history files in $DOUT_S_ROOT"
-	 else
-	    echo "History time slice files will be saved after variable time series files"
-	    echo "are generated. Please manually remove history files in order to"
-	    echo "conserve disk space."
-	 endif
-         echo "Starting generating variable time series files to $DOUT_S_ROOT"
-	 ./Tools/tseries_generate.submit >>& $CASEROOT/tseriesStatus
-         echo "Completed generating variable time series files to $DOUT_S_ROOT"
-     else
-	 echo "Variable time series file generation depends on $DOUT_S and $DOUT_S_SAVE_ALL_ON_DISK set to TRUE"
-	 echo "Variable time series files were not generated."   
-     endif
-  endif
 endif
 
 # -------------------------------------------------------------------------

--- a/scripts/Tools/st_archive
+++ b/scripts/Tools/st_archive
@@ -193,7 +193,7 @@ ADDITIONAL XML / ENVIRONMENT VARIABLES USED BY THE SHORT TERM ARCHIVER THAT ARE 
     DOUT_S_SAVE_EVERY_NTH_RESTART_FILE_SET  [integer] - If value is greater than 0 (default), then only save the nth restart set 
                                                         in the \$DOUT_S_ROOT/rest location. Always preserve the most recent restart set regardless.
 
-    DOUT_S_GENERATE_TSERIES	            [boolean] - If TRUE (default FALSE), then variable time-series files are created as part of the 
+    GENERATE_TIMESERIES	                    [boolean] - If TRUE (default FALSE), then variable time-series files are created as part of the 
                                                         run script. The history time-slice files are deleted from the short term archive locations
                                                         upon successful creation of the vvariable time-series files. This option requires 
                                                         the pyreshaper tool which is included with the CESM release distribution and installed
@@ -207,7 +207,7 @@ ADDITIONAL XML / ENVIRONMENT VARIABLES USED BY THE SHORT TERM ARCHIVER THAT ARE 
 							time series files from the time slice history files.
 
     DOUT_S_SAVE_HISTORY_FILES               [boolean] - If FALSE (default TRUE), then all component history time slice files are deleted from the
-                                                        DOUT_S_ROOT location. This option is used in conjunction with the DOUT_S_GENERATE_TSERIES
+                                                        DOUT_S_ROOT location. This option is used in conjunction with the GENERATE_TIMESERIES
                                                         option to eliminate the possibility of duplicating run history data in both component 
 							history time slice files and variable time series files.
 


### PR DESCRIPTION
…postrun_setup and

st_archive. That variable is now called GENERATE_TIMESERIES and resides in the env_postprocess.xml
file and is checked as part of the postprocessing steps.

Reviewed by bandre.
