### PR TITLE
Mapping tweaks

### DIFF
--- a/tools/mapping/check_maps/src/ESMF_RegridWeightGenCheck.F90
+++ b/tools/mapping/check_maps/src/ESMF_RegridWeightGenCheck.F90
@@ -642,8 +642,14 @@ program OfflineTester
               !   L1 error - avg = 1.004e-7, sigma = 2.312e-7
               !   L2 error - avg = 4.934e-6, sigma = 8.707e-6
               !   Area error - avg = 5.472e-12, sigma = 1.383e-11
+              !
+              ! NOTE(wjs, 2015-05-14)  Increasing reltwoErrorBound from 4e-5 to 1e-4 to
+              ! accommodate slightly larger differences in glc -> lnd mapping files.
+              ! (This is due to the fact that the source grid is regional, so the
+              ! destination grid ends up with some values that have 0's averaged in at
+              ! the margins of the source region.)
               reltotErrorBound = 2.0d-6
-              reltwoErrorBound = 4.0d-5
+              reltwoErrorBound = 1.0d-4
               totAreaBound = 6.8d-11
             case (3)
               !   L1 error - avg = 2.203e-3, sigma = 2.857e-3

--- a/tools/mapping/gen_mapping_files/gen_ESMF_mapping_file/README
+++ b/tools/mapping/gen_mapping_files/gen_ESMF_mapping_file/README
@@ -73,8 +73,8 @@ where
    point).
  --machine (or -mach)
    Name of the machine you are running on. Currently supports yellowstone,
-   geyser, caldera, and jaguar. Note that this script will determines the
-   machine name automatically from the hostfile command.
+   geyser, caldera, pronghorn, and jaguar. Note that this script will
+   determine the machine name automatically from the hostfile command.
  -d
    toggle debug-only 
  --help or -h  

--- a/tools/mapping/gen_mapping_files/gen_ESMF_mapping_file/create_ESMF_map.sh
+++ b/tools/mapping/gen_mapping_files/gen_ESMF_mapping_file/create_ESMF_map.sh
@@ -4,7 +4,7 @@
 # SVN $URL: https://svn-ccsm-models.cgd.ucar.edu/tools/mapping/trunk_tags/mapping_141106/gen_mapping_files/gen_ESMF_mapping_file/create_ESMF_map.sh $
 #
 # Create needed mapping files for gen_domain and coupler mapping
-# Currently supported on yellowstone, geyser, caldera and jaguarpf
+# Currently supported on yellowstone, geyser, caldera, pronghorn, and jaguarpf
 # 
 #===============================================================================
 echo $0
@@ -71,8 +71,8 @@ usage() {
   echo '   point).'
   echo ' --machine (or -mach)'
   echo '   Name of the machine you are running on. Currently supports yellowstone,'
-  echo '   geyser, caldera, and jaguar. Note that this script will determines the'
-  echo '   machine name automatically from the hostfile command.'
+  echo '   geyser, caldera, pronghorn, and jaguar. Note that this script will'
+  echo '   determine the machine name automatically from the hostfile command.'
   echo ' -d'
   echo '   toggle debug-only '
   echo ' --help or -h  '
@@ -80,10 +80,10 @@ usage() {
   echo ''
   echo 'You can also set the following env variables:'
   echo '  ESMFBIN_PATH - Path to ESMF binaries '
-  echo '                 (Leave unset on yellowstone and caldera and the tool'
+  echo '                 (Leave unset on yellowstone/caldera/pronghorn and the tool'
   echo '                 will be loaded from modules)'
   echo '  MPIEXEC ------ Name of mpirun executable'
-  echo '                 (default is mpirun.lsf on yellowstone and caldera; if'
+  echo '                 (default is mpirun.lsf on yellowstone/caldera/pronghorn; if'
   echo '                 you run interactively on yellowstone, mpi is not used)'
   echo '  REGRID_PROC -- Number of MPI processors to use (jaguar only!)'
   echo '                 (default is 8)'
@@ -231,6 +231,9 @@ if [ $MACH == "UNSET" ]; then
     caldera* )
       MACH="caldera"
     ;;
+    pronghorn* )
+      MACH="pronghorn"
+    ;;
     jaguarpf* )
       MACH="jaguar"
     ;;
@@ -306,8 +309,8 @@ fi
 #-------------------------------------------------------------------------------
  
 case $MACH in
-  ## yellowstone, geyser, or caldera
-  "yellowstone" | "geyser" | "caldera" )
+  ## yellowstone, geyser, caldera, or pronghorn
+  "yellowstone" | "geyser" | "caldera" | "pronghorn" )
     # From tcsh, script will not find module command
     # So check to see if module works, otherwise source an init file
     module list > /dev/null 2>&1 || source /etc/profile.d/modules.sh


### PR DESCRIPTION
Two minor fixes to mapping tools:

(1) allow running on pronghorn

(2) increase tolerance in check_maps

Mike, I note in the log message why the tolerance increase was needed in this case. One mapping file that demonstrates this problem is:

/glade/p/cesmdata/cseg/inputdata/cpl/gridmaps/gland10km/map_gland10km_TO_fv0.9x1.25_aave.150514.nc

With test map here:

/glade/p/work/sacks/cesm_code/cime/tools/mapping/check_maps/test_map_gland10km_TO_fv0.9x1.25_aave.150514.nc
