### PR TITLE
Add saturation vapor pressure module and optimizations to share code.

### DIFF
--- a/driver_cpl/bld/build-namelist
+++ b/driver_cpl/bld/build-namelist
@@ -411,6 +411,11 @@ add_default($nl, 'orb_mode');
 add_default($nl, 'orb_iyear');
 add_default($nl, 'orb_iyear_align');
 
+add_default($nl, 'wv_sat_scheme');
+add_default($nl, 'wv_sat_transition_start');
+add_default($nl, 'wv_sat_use_tables');
+add_default($nl, 'wv_sat_table_spacing');
+
 add_default($nl, 'budget_inst');
 add_default($nl, 'budget_daily');
 add_default($nl, 'budget_month');

--- a/driver_cpl/bld/namelist_files/namelist_defaults_drv.xml
+++ b/driver_cpl/bld/namelist_files/namelist_defaults_drv.xml
@@ -63,6 +63,11 @@
 <orb_iyear>1990</orb_iyear>
 <orb_iyear_align>1990</orb_iyear_align>
 
+<wv_sat_scheme>GoffGratch</wv_sat_scheme>
+<wv_sat_transition_start>20.0D0</wv_sat_transition_start>
+<wv_sat_use_tables>.false.</wv_sat_use_tables>
+<wv_sat_table_spacing>1.0D0</wv_sat_table_spacing>
+
 <timing_dir>./timing</timing_dir>
 
 <tchkpt_dir>./timing/checkpoints</tchkpt_dir>

--- a/driver_cpl/bld/namelist_files/namelist_definition_drv.xml
+++ b/driver_cpl/bld/namelist_files/namelist_definition_drv.xml
@@ -521,7 +521,7 @@ id="cpl_seq_option"
 type="char*64"
 category="expdef"
 group="seq_infodata_inparm"
-valid_values="CESM1_ORIG,CESM1_MOD,CESM1_ORIG_TIGHT,CESM1_MOD_TIGHT,RASM_OPTION1,RASM_OPTION2"
+valid_values="CESM1_ORIG,CESM1_MOD,CESM1_ORIG_TIGHT,CESM1_MOD_TIGHT,RASM_OPTION1,RASM_OPTION2">
 Set the coupler sequencing.  See CPL_SEQ_OPTION in env_run.
 default: CESM1_MOD
 </entry>
@@ -1269,7 +1269,7 @@ type="real"
 category="driver" 
 group="seq_infodata_inparm">
 Abort model if coupler timestep wallclock time exceeds this value, ignored if 0,
-if < 0 then use abs(max_cplstep_time)*cktime as the threshold.
+if &lt; 0 then use abs(max_cplstep_time)*cktime as the threshold.
 default: 0 
 </entry>
 

--- a/driver_cpl/bld/namelist_files/namelist_definition_drv.xml
+++ b/driver_cpl/bld/namelist_files/namelist_definition_drv.xml
@@ -344,6 +344,53 @@ default: SHR_ORB_UNDEF_REAL (1.e36)
 (Not currently used in build-namelist)
 </entry>
 
+<entry
+id="wv_sat_scheme"
+type="char*16"
+category="wv_sat"
+group="seq_infodata_inparm"
+valid_values="GoffGratch,MurphyKoop,Bolton,Flatau">
+Type of water vapor saturation vapor pressure scheme employed. 'GoffGratch' for
+Goff and Gratch (1946); 'MurphyKoop' for Murphy and Koop (2005); 'Bolton' for
+Bolton (1980); 'Flatau' for Flatau, Walko, and Cotton (1992).
+Default: GoffGratch
+</entry>
+
+<entry
+id="wv_sat_transition_start"
+type="real"
+category="wv_sat"
+group="seq_infodata_inparm">
+Width of the liquid-ice transition range in mixed-phase water saturation vapor
+pressure calculations. The range always ends at 0 degrees Celsius, so this
+variable only affects the start of the transition.
+Default: 20K
+
+WARNING: CAM is tuned to the default value of this variable. Because it affects
+so many different parameterizations, changes to this variable may require a
+significant retuning of CAM's cloud physics to give reasonable results.
+</entry>
+
+<entry
+id="wv_sat_use_tables"
+type="logical"
+category="wv_sat"
+group="seq_infodata_inparm">
+Whether or not to produce lookup tables at init time to use as a cache for
+saturation vapor pressure.
+Default: .false.
+</entry>
+
+<entry
+id="wv_sat_table_spacing"
+type="real"
+category="wv_sat"
+group="seq_infodata_inparm">
+Temperature resolution of saturation vapor pressure lookup tables in Kelvin.
+(This is only used if wv_sat_use_tables is .true.)
+Default: 1.0
+</entry>
+
 <entry 
 id="flux_epbal"
 type="char*8"

--- a/driver_cpl/driver/cesm_comp_mod.F90
+++ b/driver_cpl/driver/cesm_comp_mod.F90
@@ -732,8 +732,8 @@ subroutine cesm_pre_init2()
    use pio, only : file_desc_t, pio_closefile, pio_file_is_open
    use shr_const_mod, only: shr_const_tkfrz, shr_const_tktrip, &
         shr_const_mwwv, shr_const_mwdair
-   use shr_wv_sat_mod, only: wv_sat_set_default, wv_sat_init, &
-        WVSatTableSpec, wv_sat_make_tables
+   use shr_wv_sat_mod, only: shr_wv_sat_set_default, shr_wv_sat_init, &
+        ShrWVSatTableSpec, shr_wv_sat_make_tables
    implicit none
    type(file_desc_t) :: pioid
    integer :: maxthreads
@@ -744,7 +744,7 @@ subroutine cesm_pre_init2()
    real(r8) :: wv_sat_table_spacing
    character(CL) :: errstring
 
-   type(WVSatTableSpec) :: liquid_spec, ice_spec, mixed_spec
+   type(ShrWVSatTableSpec) :: liquid_spec, ice_spec, mixed_spec
 
    real(r8), parameter :: epsilo = shr_const_mwwv/shr_const_mwdair
 
@@ -952,15 +952,15 @@ subroutine cesm_pre_init2()
         wv_sat_use_tables=wv_sat_use_tables,             &
         wv_sat_table_spacing=wv_sat_table_spacing)
 
-   if (.not. wv_sat_set_default(wv_sat_scheme)) then
+   if (.not. shr_wv_sat_set_default(wv_sat_scheme)) then
       call shr_sys_abort('Invalid wv_sat_scheme.')
    end if
 
-   call wv_sat_init(shr_const_tkfrz, shr_const_tktrip, &
+   call shr_wv_sat_init(shr_const_tkfrz, shr_const_tktrip, &
         wv_sat_transition_start, epsilo, errstring)
 
    if (errstring /= "") then
-      call shr_sys_abort('wv_sat_init: '//trim(errstring))
+      call shr_sys_abort('shr_wv_sat_init: '//trim(errstring))
    end if
 
    ! The below produces internal lookup tables in the range 175-374K for
@@ -970,13 +970,13 @@ subroutine cesm_pre_init2()
    ! practice users will want to change them *very* rarely if ever, which
    ! is why only the spacing is in the namelist.
    if (wv_sat_use_tables) then
-      liquid_spec = WVSatTableSpec(ceiling(200._r8/wv_sat_table_spacing), &
+      liquid_spec = ShrWVSatTableSpec(ceiling(200._r8/wv_sat_table_spacing), &
            175._r8, wv_sat_table_spacing)
-      ice_spec = WVSatTableSpec(ceiling(150._r8/wv_sat_table_spacing), &
+      ice_spec = ShrWVSatTableSpec(ceiling(150._r8/wv_sat_table_spacing), &
            125._r8, wv_sat_table_spacing)
-      mixed_spec = WVSatTableSpec(ceiling(250._r8/wv_sat_table_spacing), &
+      mixed_spec = ShrWVSatTableSpec(ceiling(250._r8/wv_sat_table_spacing), &
            125._r8, wv_sat_table_spacing)
-      call wv_sat_make_tables(liquid_spec, ice_spec, mixed_spec)
+      call shr_wv_sat_make_tables(liquid_spec, ice_spec, mixed_spec)
    end if
 
    call seq_infodata_putData(infodata, &
@@ -3575,7 +3575,7 @@ end subroutine cesm_init
  subroutine cesm_final()
 
    use shr_pio_mod, only : shr_pio_finalize
-   use shr_wv_sat_mod, only: wv_sat_final
+   use shr_wv_sat_mod, only: shr_wv_sat_final
    implicit none
 
    !------------------------------------------------------------------------
@@ -3610,7 +3610,7 @@ end subroutine cesm_init
    ! End the run cleanly
    !------------------------------------------------------------------------
 
-   call wv_sat_final()
+   call shr_wv_sat_final()
 
    call shr_pio_finalize( )
    

--- a/driver_cpl/driver/cesm_comp_mod.F90
+++ b/driver_cpl/driver/cesm_comp_mod.F90
@@ -3575,6 +3575,7 @@ end subroutine cesm_init
  subroutine cesm_final()
 
    use shr_pio_mod, only : shr_pio_finalize
+   use shr_wv_sat_mod, only: wv_sat_final
    implicit none
 
    !------------------------------------------------------------------------
@@ -3608,6 +3609,8 @@ end subroutine cesm_init
    !------------------------------------------------------------------------
    ! End the run cleanly
    !------------------------------------------------------------------------
+
+   call wv_sat_final()
 
    call shr_pio_finalize( )
    

--- a/driver_cpl/shr/seq_infodata_mod.F90
+++ b/driver_cpl/shr/seq_infodata_mod.F90
@@ -1938,7 +1938,7 @@ subroutine seq_infodata_Check( infodata )
 
   use shr_assert_mod,   only: shr_assert_in_domain
   use shr_string_mod,   only: shr_string_listIntersect
-  use shr_wv_sat_mod,   only: wv_sat_get_scheme_idx, wv_sat_valid_idx
+  use shr_wv_sat_mod,   only: shr_wv_sat_get_scheme_idx, shr_wv_sat_valid_idx
 
   implicit none
 
@@ -2015,7 +2015,7 @@ subroutine seq_infodata_Check( infodata )
        call shr_sys_abort(subname//': orb params incorrect')
     endif
 
-    if (.not. wv_sat_valid_idx(wv_sat_get_scheme_idx(trim(infodata%wv_sat_scheme)))) then
+    if (.not. shr_wv_sat_valid_idx(shr_wv_sat_get_scheme_idx(trim(infodata%wv_sat_scheme)))) then
        call shr_sys_abort(subname//': "'//trim(infodata%wv_sat_scheme)//'" &
             &is not a recognized saturation vapor pressure scheme name')
     end if

--- a/driver_cpl/shr/seq_infodata_mod.F90
+++ b/driver_cpl/shr/seq_infodata_mod.F90
@@ -99,6 +99,10 @@ MODULE seq_infodata_mod
       real(SHR_KIND_R8)       :: orb_obliqr      ! See shr_orb_mod
       real(SHR_KIND_R8)       :: orb_lambm0      ! See shr_orb_mod
       real(SHR_KIND_R8)       :: orb_mvelpp      ! See shr_orb_mod
+      character(SHR_KIND_CS)  :: wv_sat_scheme   ! Water vapor saturation pressure scheme
+      real(SHR_KIND_R8)       :: wv_sat_transition_start ! Saturation transition range
+      logical                 :: wv_sat_use_tables   ! Saturation pressure lookup tables
+      real(SHR_KIND_R8)       :: wv_sat_table_spacing! Saturation pressure table resolution
       character(SHR_KIND_CL)  :: flux_epbal      ! selects E,P,R adjustment technique 
       logical                 :: flux_albav      ! T => no diurnal cycle in ocn albedos
       real(SHR_KIND_R8)       :: wall_time_limit ! force stop time limit (hours)
@@ -292,6 +296,10 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
     real(SHR_KIND_R8)      :: orb_obliqr         ! Obliquity in radians
     real(SHR_KIND_R8)      :: orb_lambm0         ! lon of per at vernal equ
     real(SHR_KIND_R8)      :: orb_mvelpp         ! mvelp plus pi
+    character(SHR_KIND_CS) :: wv_sat_scheme      ! Water vapor saturation pressure scheme
+    real(SHR_KIND_R8)      :: wv_sat_transition_start! Saturation transition range
+    logical                :: wv_sat_use_tables  ! Saturation pressure lookup tables
+    real(SHR_KIND_R8)      :: wv_sat_table_spacing   ! Saturation pressure table resolution
     character(SHR_KIND_CL) :: flux_epbal         ! selects E,P,R adjustment technique 
     logical                :: flux_albav         ! T => no diurnal cycle in ocn albedos
     real(SHR_KIND_R8)      :: wall_time_limit    ! force stop time limit (hours)
@@ -351,6 +359,8 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
          perpetual, perpetual_ymd, flux_epbal, flux_albav, &
          orb_iyear_align, orb_mode, wall_time_limit,       &
          orb_iyear, orb_obliq, orb_eccen, orb_mvelp,       &
+         wv_sat_scheme, wv_sat_transition_start,           &
+         wv_sat_use_tables, wv_sat_table_spacing,          &
          ice_gnam, rof_gnam, glc_gnam, wav_gnam,           &
          atm_gnam, lnd_gnam, ocn_gnam, cpl_decomp,         &
          shr_map_dopole, vect_map, aoflux_grid, do_histinit,  &
@@ -410,6 +420,10 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
        orb_obliq             = SHR_ORB_UNDEF_REAL
        orb_eccen             = SHR_ORB_UNDEF_REAL
        orb_mvelp             = SHR_ORB_UNDEF_REAL
+       wv_sat_scheme         = "GoffGratch"
+       wv_sat_transition_start = 20.0
+       wv_sat_use_tables     = .false.
+       wv_sat_table_spacing  = 1.0
        flux_epbal            = 'off'
        flux_albav            = .false.
        wall_time_limit       = -1.0
@@ -499,6 +513,10 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
        infodata%outPathRoot           = outPathRoot
        infodata%perpetual             = perpetual
        infodata%perpetual_ymd         = perpetual_ymd
+       infodata%wv_sat_scheme         = wv_sat_scheme
+       infodata%wv_sat_transition_start = wv_sat_transition_start
+       infodata%wv_sat_use_tables     = wv_sat_use_tables
+       infodata%wv_sat_table_spacing  = wv_sat_table_spacing
        infodata%flux_epbal            = flux_epbal
        infodata%flux_albav            = flux_albav
        infodata%wall_time_limit       = wall_time_limit
@@ -782,9 +800,10 @@ SUBROUTINE seq_infodata_GetData( infodata, case_name, case_desc, timing_dir,  &
            histaux_a2x    , histaux_a2x3hr, histaux_a2x3hrp , histaux_l2x1yr, &
            histaux_a2x24hr, histaux_l2x   , histaux_r2x     , orb_obliq,      &
            cpl_cdf64, orb_iyear, orb_iyear_align, orb_mode, orb_mvelp,        &
-           orb_eccen, orb_obliqr, orb_lambm0, orb_mvelpp, glc_phase, rof_phase, &
-           atm_phase, lnd_phase, ocn_phase, ice_phase, wav_phase,             &
-           wav_nx, wav_ny, atm_nx, atm_ny,                                    &
+           orb_eccen, orb_obliqr, orb_lambm0, orb_mvelpp, wv_sat_scheme,      &
+           wv_sat_transition_start, wv_sat_use_tables, wv_sat_table_spacing,  &
+           glc_phase, rof_phase, atm_phase, lnd_phase, ocn_phase, ice_phase,  &
+           wav_phase, wav_nx, wav_ny, atm_nx, atm_ny,                         &
            lnd_nx, lnd_ny, rof_nx, rof_ny, ice_nx, ice_ny, ocn_nx, ocn_ny,    &
            glc_nx, glc_ny, eps_frac, eps_amask,                               &
            eps_agrid, eps_aarea, eps_omask, eps_ogrid, eps_oarea,             &
@@ -831,6 +850,10 @@ SUBROUTINE seq_infodata_GetData( infodata, case_name, case_desc, timing_dir,  &
    real(SHR_KIND_R8)   ,optional, intent(OUT) :: orb_lambm0    ! See shr_orb_mod
    real(SHR_KIND_R8)   ,optional, intent(OUT) :: orb_mvelpp    ! See shr_orb_mod
    real(SHR_KIND_R8)   ,optional, intent(OUT) :: orb_mvelp     ! See shr_orb_mod
+   character(len=*)    ,optional, intent(OUT) :: wv_sat_scheme ! Water vapor saturation pressure scheme
+   real(SHR_KIND_R8)   ,optional, intent(OUT) :: wv_sat_transition_start   ! Saturation transition range
+   logical             ,optional, intent(OUT) :: wv_sat_use_tables ! Saturation pressure lookup tables
+   real(SHR_KIND_R8)   ,optional, intent(OUT) :: wv_sat_table_spacing  ! Saturation pressure table resolution
    character(len=*)    ,optional, intent(OUT) :: flux_epbal    ! selects E,P,R adjustment technique 
    logical             ,optional, intent(OUT) :: flux_albav    ! T => no diurnal cycle in ocn albedos
    real(SHR_KIND_R8)   ,optional, intent(OUT) :: wall_time_limit ! force stop wall time (hours)
@@ -974,6 +997,11 @@ SUBROUTINE seq_infodata_GetData( infodata, case_name, case_desc, timing_dir,  &
     if ( present(orb_lambm0)     ) orb_lambm0     = infodata%orb_lambm0   
     if ( present(orb_mvelpp)     ) orb_mvelpp     = infodata%orb_mvelpp
     if ( present(orb_mvelp)      ) orb_mvelp      = infodata%orb_mvelp
+    if ( present(wv_sat_scheme)  ) wv_sat_scheme  = infodata%wv_sat_scheme
+    if ( present(wv_sat_transition_start)) &
+         wv_sat_transition_start = infodata%wv_sat_transition_start
+    if ( present(wv_sat_use_tables)) wv_sat_use_tables = infodata%wv_sat_use_tables
+    if ( present(wv_sat_table_spacing)) wv_sat_table_spacing = infodata%wv_sat_table_spacing
     if ( present(flux_epbal)     ) flux_epbal     = infodata%flux_epbal
     if ( present(flux_albav)     ) flux_albav     = infodata%flux_albav
     if ( present(wall_time_limit)) wall_time_limit= infodata%wall_time_limit
@@ -1121,9 +1149,10 @@ SUBROUTINE seq_infodata_PutData( infodata, case_name, case_desc, timing_dir,  &
            histaux_a2x    , histaux_a2x3hr, histaux_a2x3hrp , histaux_l2x1yr, &
            histaux_a2x24hr, histaux_l2x   , histaux_r2x     , orb_obliq,      &
            cpl_cdf64, orb_iyear, orb_iyear_align, orb_mode, orb_mvelp,        &
-           orb_eccen, orb_obliqr, orb_lambm0, orb_mvelpp, glc_phase, rof_phase, &
-           atm_phase, lnd_phase, ocn_phase, ice_phase, wav_phase,             &
-           wav_nx, wav_ny, atm_nx, atm_ny,                                    &
+           orb_eccen, orb_obliqr, orb_lambm0, orb_mvelpp, wv_sat_scheme,      &
+           wv_sat_transition_start, wv_sat_use_tables, wv_sat_table_spacing,  &
+           glc_phase, rof_phase, atm_phase, lnd_phase, ocn_phase, ice_phase,  &
+           wav_phase, wav_nx, wav_ny, atm_nx, atm_ny,                         &
            lnd_nx, lnd_ny, rof_nx, rof_ny, ice_nx, ice_ny, ocn_nx, ocn_ny,    &
            glc_nx, glc_ny, eps_frac, eps_amask,                               &
            eps_agrid, eps_aarea, eps_omask, eps_ogrid, eps_oarea,             &
@@ -1170,6 +1199,10 @@ SUBROUTINE seq_infodata_PutData( infodata, case_name, case_desc, timing_dir,  &
    real(SHR_KIND_R8)   ,optional, intent(IN) :: orb_lambm0    ! See shr_orb_mod
    real(SHR_KIND_R8)   ,optional, intent(IN) :: orb_mvelpp    ! See shr_orb_mod
    real(SHR_KIND_R8)   ,optional, intent(IN) :: orb_mvelp     ! See shr_orb_mod
+   character(len=*)    ,optional, intent(IN) :: wv_sat_scheme ! Water vapor saturation pressure scheme
+   real(SHR_KIND_R8)   ,optional, intent(IN) :: wv_sat_transition_start  ! Saturation transition range
+   logical             ,optional, intent(IN) :: wv_sat_use_tables ! Saturation pressure lookup tables
+   real(SHR_KIND_R8)   ,optional, intent(IN) :: wv_sat_table_spacing  ! Saturation pressure table resolution
    character(len=*)    ,optional, intent(IN) :: flux_epbal    ! selects E,P,R adjustment technique 
    logical             ,optional, intent(IN) :: flux_albav    ! T => no diurnal cycle in ocn albedos
    real(SHR_KIND_R8)   ,optional, intent(IN) :: wall_time_limit ! force stop wall time (hours)
@@ -1311,6 +1344,11 @@ SUBROUTINE seq_infodata_PutData( infodata, case_name, case_desc, timing_dir,  &
     if ( present(orb_lambm0)     ) infodata%orb_lambm0     = orb_lambm0   
     if ( present(orb_mvelpp)     ) infodata%orb_mvelpp     = orb_mvelpp
     if ( present(orb_mvelp)      ) infodata%orb_mvelp      = orb_mvelp
+    if ( present(wv_sat_scheme)  ) infodata%wv_sat_scheme  = wv_sat_scheme
+    if ( present(wv_sat_transition_start)) &
+         infodata%wv_sat_transition_start = wv_sat_transition_start
+    if ( present(wv_sat_use_tables)) infodata%wv_sat_use_tables = wv_sat_use_tables
+    if ( present(wv_sat_table_spacing)) infodata%wv_sat_table_spacing = wv_sat_table_spacing
     if ( present(flux_epbal)     ) infodata%flux_epbal     = flux_epbal
     if ( present(flux_albav)     ) infodata%flux_albav     = flux_albav
     if ( present(wall_time_limit)) infodata%wall_time_limit= wall_time_limit
@@ -1476,6 +1514,10 @@ subroutine seq_infodata_bcast(infodata,mpicom)
     call shr_mpi_bcast(infodata%orb_obliqr,            mpicom)
     call shr_mpi_bcast(infodata%orb_lambm0,            mpicom)
     call shr_mpi_bcast(infodata%orb_mvelpp,            mpicom)
+    call shr_mpi_bcast(infodata%wv_sat_scheme,         mpicom)
+    call shr_mpi_bcast(infodata%wv_sat_transition_start, mpicom)
+    call shr_mpi_bcast(infodata%wv_sat_use_tables,     mpicom)
+    call shr_mpi_bcast(infodata%wv_sat_table_spacing,  mpicom)
     call shr_mpi_bcast(infodata%flux_epbal,            mpicom)
     call shr_mpi_bcast(infodata%flux_albav,            mpicom)
     call shr_mpi_bcast(infodata%wall_time_limit,       mpicom)
@@ -1894,7 +1936,9 @@ subroutine seq_infodata_Check( infodata )
 
 ! !USES:
 
+  use shr_assert_mod,   only: shr_assert_in_domain
   use shr_string_mod,   only: shr_string_listIntersect
+  use shr_wv_sat_mod,   only: wv_sat_get_scheme_idx, wv_sat_valid_idx
 
   implicit none
 
@@ -1970,6 +2014,18 @@ subroutine seq_infodata_Check( infodata )
         infodata%orb_lambm0 == SHR_ORB_UNDEF_REAL) then
        call shr_sys_abort(subname//': orb params incorrect')
     endif
+
+    if (.not. wv_sat_valid_idx(wv_sat_get_scheme_idx(trim(infodata%wv_sat_scheme)))) then
+       call shr_sys_abort(subname//': "'//trim(infodata%wv_sat_scheme)//'" &
+            &is not a recognized saturation vapor pressure scheme name')
+    end if
+
+    ! Transition range averaging method is only valid for:
+    ! -40 deg C <= T <= 0 deg C
+    call shr_assert_in_domain(infodata%wv_sat_transition_start, &
+         ge=0._SHR_KIND_R8, le=40._SHR_KIND_R8, &
+         varname="wv_sat_transition_start",&
+         msg="Invalid transition temperature range.")
 
     if ((trim(infodata%aoflux_grid) /= 'ocn') .and. &
         (trim(infodata%aoflux_grid) /= 'atm') .and. &
@@ -2072,6 +2128,11 @@ SUBROUTINE seq_infodata_print( infodata )
        write(logunit,F0I) subname,'orb_iyear                = ', infodata%orb_iyear
        write(logunit,F0I) subname,'orb_iyear_align          = ', infodata%orb_iyear_align
      endif
+
+       write(logunit,F0A) subname,'wv_sat_scheme            = ', trim(infodata%wv_sat_scheme)
+       write(logunit,F0R) subname,'wv_sat_transition_start  = ', infodata%wv_sat_transition_start
+       write(logunit,F0L) subname,'wv_sat_use_tables        = ', infodata%wv_sat_use_tables
+       write(logunit,F0R) subname,'wv_sat_table_spacing     = ', infodata%wv_sat_table_spacing
 
        write(logunit,F0A) subname,'flux_epbal               = ', trim(infodata%flux_epbal)
        write(logunit,F0L) subname,'flux_albav               = ', infodata%flux_albav

--- a/driver_cpl/shr/seq_infodata_mod.F90
+++ b/driver_cpl/shr/seq_infodata_mod.F90
@@ -2020,8 +2020,15 @@ subroutine seq_infodata_Check( infodata )
             &is not a recognized saturation vapor pressure scheme name')
     end if
 
-    ! Transition range averaging method is only valid for:
+    ! A transition range averaging method in CAM is only valid for:
+    !
     ! -40 deg C <= T <= 0 deg C
+    !
+    ! shr_wv_sat_mod itself checks for values with the wrong sign, but we
+    ! have to check that the range is no more than 40 deg C here. Even
+    ! though this is a CAM-specific restriction, it's not really likely
+    ! that any other parameterization will be dealing with mixed-phase
+    ! water below 40 deg C anyway.
     call shr_assert_in_domain(infodata%wv_sat_transition_start, &
          ge=0._SHR_KIND_R8, le=40._SHR_KIND_R8, &
          varname="wv_sat_transition_start",&

--- a/machines/Depends.intel
+++ b/machines/Depends.intel
@@ -11,9 +11,16 @@ uwshcu.o
 REDUCED_OPT_OBJS=\
 SatellitePhenologyMod.o
 
+# shr_wv_sat_mod does not need to have better than ~0.1% precision, and benefits
+# enormously from a lower precision in the vector functions.
+REDUCED_PRECISION_OBJS=\
+shr_wv_sat_mod.o
+
 ifeq ($(DEBUG),FALSE)
   $(PERFOBJS): %.o: %.F90
 	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -O3  -no-prec-div $<
   $(REDUCED_OPT_OBJS): %.o: %.F90
 	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -O1 $<
+  $(REDUCED_PRECISION_OBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -fimf-precision=low -fp-model fast $<
 endif

--- a/share/csm_share/shr/CMakeLists.txt
+++ b/share/csm_share/shr/CMakeLists.txt
@@ -9,7 +9,8 @@ list(APPEND share_sources "${share_genf90_sources}")
 
 list(APPEND share_sources shr_file_mod.F90 shr_kind_mod.F90 shr_const_mod.F90
   shr_sys_mod.F90 shr_log_mod.F90 shr_orb_mod.F90 shr_spfn_mod.F90 shr_strconvert_mod.F90
-  shr_nl_mod.F90 shr_string_mod.F90 shr_timer_mod.F90 shr_vmath_mod.F90)
+  shr_nl_mod.F90 shr_string_mod.F90 shr_timer_mod.F90 shr_vmath_mod.F90
+  shr_wv_sat_mod.F90)
 
 # Build a separate list containing the mct wrapper and its dependencies. That
 # way, this list can be easily included in unit test builds that link to mct,

--- a/share/csm_share/shr/shr_spfn_mod.F90
+++ b/share/csm_share/shr/shr_spfn_mod.F90
@@ -9,7 +9,10 @@
 ! HAVE_ERF_EXTERNALS: erf and erfc
 
 ! These compilers have the intrinsics.
-#if defined CPRIBM || defined CPRINTEL || defined __GFORTRAN__ || defined CPRCRAY
+! Intel also has them (and Cray), but as of mid-2015, our implementation is
+! actually faster, in part because they do not properly vectorize, so we
+! pretend that the compiler version doesn't exist.
+#if defined CPRIBM || defined __GFORTRAN__
 #define HAVE_GAMMA_INTRINSICS
 #define HAVE_ERF_INTRINSICS
 #endif

--- a/share/csm_share/shr/shr_wv_sat_mod.F90
+++ b/share/csm_share/shr/shr_wv_sat_mod.F90
@@ -113,7 +113,6 @@ integer, parameter :: rk = selected_real_kind(12)
 
 real(rk) :: tmelt   ! Melting point of water at 1 atm (K)
 real(rk) :: h2otrip ! Triple point temperature of water (K)
-real(rk) :: tboil   ! Boiling point of water at 1 atm (K)
 
 real(rk) :: ttrice  ! Ice-water transition range
 
@@ -195,11 +194,10 @@ contains
 !---------------------------------------------------------------------
 
 ! Get physical constants
-subroutine wv_sat_init(tmelt_in, h2otrip_in, tboil_in, &
-     ttrice_in, epsilo_in, errstring)
+subroutine wv_sat_init(tmelt_in, h2otrip_in, ttrice_in, epsilo_in, &
+     errstring)
   real(rk), intent(in) :: tmelt_in
   real(rk), intent(in) :: h2otrip_in
-  real(rk), intent(in) :: tboil_in
   real(rk), intent(in) :: ttrice_in
   real(rk), intent(in) :: epsilo_in
   character(len=*), intent(out)  :: errstring
@@ -214,7 +212,6 @@ subroutine wv_sat_init(tmelt_in, h2otrip_in, tboil_in, &
 
   tmelt = tmelt_in
   h2otrip = h2otrip_in
-  tboil = tboil_in
   ttrice = ttrice_in
   epsilo = epsilo_in
 
@@ -945,6 +942,11 @@ end function lookup_svp_in_table
 pure function GoffGratch_svp_liquid(t) result(es)
   real(rk), intent(in) :: t  ! Temperature in Kelvin
   real(rk) :: es             ! SVP in Pa
+
+  ! Boiling point of water at 1 atm (K)
+  ! This is not really the most accurate value, but it is the one that the
+  ! Goff & Gratch scheme was designed to use, so we hard-code it.
+  real(rk), parameter :: tboil = 373.16_rk
 
   ! uncertain below -70 C
   es = 10._rk**(-7.90298_rk*(tboil/t-1._rk)+ &

--- a/share/csm_share/shr/shr_wv_sat_mod.F90
+++ b/share/csm_share/shr/shr_wv_sat_mod.F90
@@ -9,7 +9,7 @@ module shr_wv_sat_mod
 ! Typical usage of this module:
 !
 ! Init:
-! call wv_sat_methods_init(<constants>, errstring)
+! call wv_sat_init(<constants>, errstring)
 !
 ! Get scheme index from a name string:
 ! scheme_idx = wv_sat_get_scheme_idx("GoffGratch")
@@ -57,8 +57,8 @@ module shr_wv_sat_mod
 ! tables are stored in global, thread-shared variables. Therefore the following
 ! procedures are not thread-safe:
 !
-!  - wv_sat_methods_init
-!  - wv_sat_methods_final
+!  - wv_sat_init
+!  - wv_sat_final
 !  - wv_sat_set_default
 !  - wv_sat_make_tables
 !

--- a/share/csm_share/shr/shr_wv_sat_mod.F90
+++ b/share/csm_share/shr/shr_wv_sat_mod.F90
@@ -1015,7 +1015,7 @@ end function Bolton_svp_ice
 
 ! "Flatau" scheme modified from CLUBB, based on:
 !
-! ``Polynomial Fits to Saturation Vapor Pressure'' Falatau, Walko,
+! ``Polynomial Fits to Saturation Vapor Pressure'' Flatau, Walko,
 !   and Cotton.  (1992)  Journal of Applied Meteorology, Vol. 31,
 !   pp. 1507--1513
 

--- a/share/csm_share/shr/shr_wv_sat_mod.F90
+++ b/share/csm_share/shr/shr_wv_sat_mod.F90
@@ -1,0 +1,1066 @@
+module shr_wv_sat_mod
+
+! This portable module contains all CAM methods for estimating the saturation
+! vapor pressure of water.
+!
+! wv_saturation provides CAM-specific interfaces and utilities based on these
+! formulae.
+!
+! Typical usage of this module:
+!
+! Init:
+! call wv_sat_methods_init(<constants>, errstring)
+!
+! Get scheme index from a name string:
+! scheme_idx = wv_sat_get_scheme_idx("GoffGratch")
+! if (.not. wv_sat_valid_idx(scheme_idx)) <throw some error>
+!
+! Get pressures:
+! es = wv_sat_svp_liquid(t, scheme_idx)
+! es = wv_sat_svp_ice(t, scheme_idx)
+!
+! Use ice/water transition range:
+! es = wv_sat_svp_mixed(t, scheme_idx)
+!
+! Note that elemental functions cannot be pointed to, nor passed as
+! arguments. If you need to do either, it is recommended to wrap the function so
+! that it can be given an explicit (non- elemental) interface.
+!
+! Since usually only one scheme is used at a time, the scheme index is an
+! optional argument. If omitted a default scheme will be used, which is
+! initially the Goff & Gratch scheme. To change the default, you can make a call
+! like this:
+!
+! call wv_sat_set_default("MurphyKoop")
+!
+! This module has the ability to store lookup tables to cache values. To do so,
+! create a WVSatTableSpec instance for water and ice with the desired size and
+! range, then call wv_sat_make_tables like so:
+!
+! type(WVSatTableSpec) :: liquid_spec, ice_spec, mixed_spec
+!
+! liquid_spec = WVSatTableSpec(151, tmelt-50._rk, 1._rk)
+! ice_spec = WVSatTableSpec(106, tmelt-100._rk, 1._rk)
+! mixed_spec = WVSatTableSpec(21, tmelt-20._rk, 1._rk)
+! call wv_sat_make_tables(liquid_spec, ice_spec, mixed_spec)
+!
+! Currently, this module only supports making tables for the default scheme, and
+! wv_sat_make_tables must be invoked again to produce new tables if the default
+! is changed.
+!
+! Once tables are produced, all uses of the default scheme will attempt to
+! linearly interpolate values from the lookup tables. If a temperature is
+! outside the table bounds, the original scheme will be invoked as if no table
+! was present. That is, the tables will *not* be extrapolated.
+!
+! Threading note: The physical constants, the current default, and the lookup
+! tables are stored in global, thread-shared variables. Therefore the following
+! procedures are not thread-safe:
+!
+!  - wv_sat_methods_init
+!  - wv_sat_methods_final
+!  - wv_sat_set_default
+!  - wv_sat_make_tables
+!
+! If a multi-threaded application calls any of these procedures, the user is
+! responsible for ensuring that each call is perfomed by only one thread, and
+! that synchronization is performed to before and after each of these calls.
+!
+! All other public routines are thread-safe.
+
+#ifdef WV_SAT_USE_CLUBB_KIND
+! If running within CLUBB, use the same precision as CLUBB.
+use clubb_precision, only: core_rkind
+#endif
+
+implicit none
+private
+save
+
+! Initialize/finalize module and pick schemes
+public wv_sat_init
+public wv_sat_final
+public wv_sat_get_scheme_idx
+public wv_sat_valid_idx
+public wv_sat_set_default
+
+! Manage lookup tables
+public WVSatTableSpec
+public wv_sat_make_tables
+
+! Basic SVP calculations
+public wv_sat_svp_liquid
+public wv_sat_svp_ice
+public wv_sat_svp_mixed
+
+! pressure -> humidity conversion
+public wv_sat_svp_to_qsat
+
+! pressure -> mass mixing ratio conversion
+public wv_sat_svp_to_qmmr
+
+! Combined qsat operations
+public wv_sat_qsat_liquid
+public wv_sat_qsat_ice
+public wv_sat_qsat_mixed
+
+#ifdef WV_SAT_USE_CLUBB_KIND
+integer, parameter :: rk = core_rkind
+#else
+! Double precision
+integer, parameter :: rk = selected_real_kind(12)
+#endif
+
+real(rk) :: tmelt   ! Melting point of water at 1 atm (K)
+real(rk) :: h2otrip ! Triple point temperature of water (K)
+real(rk) :: tboil   ! Boiling point of water at 1 atm (K)
+
+real(rk) :: ttrice  ! Ice-water transition range
+
+real(rk) :: epsilo  ! Ice-water transition range
+real(rk) :: omeps   ! 1._rk - epsilo
+
+! Indices representing individual schemes
+integer, parameter :: Invalid_idx = -1
+! Skip 0; this was the old implementation of Goff & Gratch.
+integer, parameter :: GoffGratch_idx = 1
+integer, parameter :: MurphyKoop_idx = 2
+integer, parameter :: Bolton_idx = 3
+integer, parameter :: Flatau_idx = 4
+
+! Index representing the current default scheme.
+integer, parameter :: initial_default_idx = GoffGratch_idx
+integer :: default_idx = initial_default_idx
+
+! Type to represent a table specification.
+type WVSatTableSpec
+   integer :: table_size
+   real(rk) :: minimum
+   real(rk) :: spacing
+end type WVSatTableSpec
+
+type(WVSatTableSpec) :: liquid_table_spec
+real(rk), allocatable :: liquid_table(:)
+
+type(WVSatTableSpec) :: ice_table_spec
+real(rk), allocatable :: ice_table(:)
+
+type(WVSatTableSpec) :: mixed_table_spec
+real(rk), allocatable :: mixed_table(:)
+
+interface wv_sat_svp_liquid
+   module procedure wv_sat_svp_liquid
+   module procedure wv_sat_svp_liquid_vec
+end interface wv_sat_svp_liquid
+
+interface wv_sat_svp_ice
+   module procedure wv_sat_svp_ice
+   module procedure wv_sat_svp_ice_vec
+end interface wv_sat_svp_ice
+
+interface wv_sat_svp_mixed
+   module procedure wv_sat_svp_mixed
+   module procedure wv_sat_svp_mixed_vec
+end interface wv_sat_svp_mixed
+
+interface wv_sat_svp_to_qsat
+   module procedure wv_sat_svp_to_qsat
+   module procedure wv_sat_svp_to_qsat_vec
+end interface wv_sat_svp_to_qsat
+
+interface wv_sat_svp_to_qmmr
+   module procedure wv_sat_svp_to_qmmr
+   module procedure wv_sat_svp_to_qmmr_vec
+end interface wv_sat_svp_to_qmmr
+
+interface wv_sat_qsat_liquid
+   module procedure wv_sat_qsat_liquid
+   module procedure wv_sat_qsat_liquid_vec
+end interface wv_sat_qsat_liquid
+
+interface wv_sat_qsat_ice
+   module procedure wv_sat_qsat_ice
+   module procedure wv_sat_qsat_ice_vec
+end interface wv_sat_qsat_ice
+
+interface wv_sat_qsat_mixed
+   module procedure wv_sat_qsat_mixed
+   module procedure wv_sat_qsat_mixed_vec
+end interface wv_sat_qsat_mixed
+
+contains
+
+!---------------------------------------------------------------------
+! ADMINISTRATIVE FUNCTIONS
+!---------------------------------------------------------------------
+
+! Get physical constants
+subroutine wv_sat_init(tmelt_in, h2otrip_in, tboil_in, &
+     ttrice_in, epsilo_in, errstring)
+  real(rk), intent(in) :: tmelt_in
+  real(rk), intent(in) :: h2otrip_in
+  real(rk), intent(in) :: tboil_in
+  real(rk), intent(in) :: ttrice_in
+  real(rk), intent(in) :: epsilo_in
+  character(len=*), intent(out)  :: errstring
+
+  errstring = ' '
+
+  if (ttrice_in < 0._rk) then
+     write(errstring,*) 'wv_sat_init: ERROR: ', &
+          ttrice_in,' was input for ttrice, but negative range is invalid.'
+     return
+  end if
+
+  tmelt = tmelt_in
+  h2otrip = h2otrip_in
+  tboil = tboil_in
+  ttrice = ttrice_in
+  epsilo = epsilo_in
+
+  omeps = 1._rk - epsilo
+
+end subroutine wv_sat_init
+
+! Reset module data to the original state (primarily for testing purposes).
+! It doesn't seem worthwhile to reset the constants, so just deal with options
+! and dynamic memory here.
+subroutine wv_sat_final()
+
+  default_idx = initial_default_idx
+
+  if (allocated(liquid_table)) deallocate(liquid_table)
+  if (allocated(ice_table)) deallocate(ice_table)
+  if (allocated(mixed_table)) deallocate(mixed_table)
+
+end subroutine wv_sat_final
+
+! Look up index by name.
+pure function wv_sat_get_scheme_idx(name) result(idx)
+  character(len=*), intent(in) :: name
+  integer :: idx
+
+  ! Several names are given to most methods in order to support the names that
+  ! CLUBB accepts.
+  select case (name)
+  case("GoffGratch", "gfdl", "GFDL")
+     idx = GoffGratch_idx
+  case("MurphyKoop")
+     idx = MurphyKoop_idx
+  case("Bolton", "bolton")
+     idx = Bolton_idx
+  case("Flatau", "flatau")
+     idx = Flatau_idx
+  case default
+     idx = Invalid_idx
+  end select
+
+end function wv_sat_get_scheme_idx
+
+! Check validity of an index from the above routine.
+pure function wv_sat_valid_idx(idx) result(status)
+  integer, intent(in) :: idx
+  logical :: status
+
+  status = (idx /= Invalid_idx)
+
+end function wv_sat_valid_idx
+
+! Set default scheme (otherwise, Goff & Gratch is default)
+! Returns a logical representing success (.true.) or
+! failure (.false.).
+function wv_sat_set_default(name) result(status)
+  character(len=*), intent(in) :: name
+  logical :: status
+
+  ! Don't want to overwrite valid default with invalid,
+  ! so assign to temporary and check it first.
+  integer :: tmp_idx
+
+  tmp_idx = wv_sat_get_scheme_idx(name)
+
+  status = wv_sat_valid_idx(tmp_idx)
+
+  ! If we have changed the default, deallocated the tables as well as setting
+  ! the new default.
+  if (status .and. tmp_idx /= default_idx) then
+     if (allocated(liquid_table)) deallocate(liquid_table)
+     if (allocated(ice_table)) deallocate(ice_table)
+     if (allocated(mixed_table)) deallocate(mixed_table)
+     default_idx = tmp_idx
+  end if
+
+end function wv_sat_set_default
+
+subroutine wv_sat_make_tables(liquid_spec_in, ice_spec_in, mixed_spec_in)
+  type(WVSatTableSpec), intent(in), optional :: liquid_spec_in
+  type(WVSatTableSpec), intent(in), optional :: ice_spec_in
+  type(WVSatTableSpec), intent(in), optional :: mixed_spec_in
+
+  if (present(liquid_spec_in)) then
+     liquid_table_spec = liquid_spec_in
+     call wv_sat_make_one_table(liquid_table_spec, wv_sat_svp_liquid_no_table, &
+          liquid_table)
+  end if
+
+  if (present(ice_spec_in)) then
+     ice_table_spec = ice_spec_in
+     call wv_sat_make_one_table(ice_table_spec, wv_sat_svp_ice_no_table, &
+          ice_table)
+  end if
+
+  if (present(mixed_spec_in)) then
+     mixed_table_spec = mixed_spec_in
+     call wv_sat_make_one_table(mixed_table_spec, wv_sat_svp_mixed_no_table, &
+          mixed_table)
+  end if
+
+end subroutine wv_sat_make_tables
+
+! Table-generating generic function (would be simpler with an object-oriented
+! design, but we want this code to be runnable on compilers with poor Fortran
+! 2003 support). This means we can't attach function pointers or methods to
+! derived types.
+subroutine wv_sat_make_one_table(table_spec, svp_function, table)
+  type(WVSatTableSpec), intent(in) :: table_spec
+  interface
+     function svp_function(t, idx) result(es)
+       import :: rk
+       real(rk), intent(in) :: t
+       integer, intent(in) :: idx
+       real(rk) :: es
+     end function svp_function
+  end interface
+  real(rk), intent(out), allocatable :: table(:)
+
+  integer :: i
+
+  allocate(table(table_spec%table_size))
+
+  do i = 1, table_spec%table_size
+     table(i) = svp_function( &
+          table_spec%minimum + table_spec%spacing*real(i-1, rk), &
+          default_idx)
+  end do
+
+end subroutine wv_sat_make_one_table
+
+!---------------------------------------------------------------------
+! UTILITIES
+!---------------------------------------------------------------------
+
+! Get saturation specific humidity given pressure and SVP.
+! Specific humidity is limited to the range 0-1.
+elemental function wv_sat_svp_to_qsat(es, p) result(qs)
+
+  real(rk), intent(in) :: es  ! SVP
+  real(rk), intent(in) :: p   ! Current pressure.
+  real(rk) :: qs
+
+  ! If pressure is less than SVP, set qs to maximum of 1.
+  if ( (p - es) <= 0._rk ) then
+     qs = 1.0_rk
+  else
+     qs = epsilo*es / (p - omeps*es)
+  end if
+
+end function wv_sat_svp_to_qsat
+
+pure function wv_sat_svp_to_qsat_vec(n, es, p) result(qs)
+
+  integer,  intent(in) :: n      ! Size of input arrays
+  real(rk), intent(in) :: es(n)  ! SVP
+  real(rk), intent(in) :: p(n)   ! Current pressure
+  real(rk) :: qs(n)
+
+  integer :: i
+
+  ! If pressure is less than SVP, set qs to maximum of 1.
+  do i = 1, n
+     if ( (p(i) - es(i)) <= 0._rk ) then
+        qs(i) = 1.0_rk
+     else
+        qs(i) = epsilo*es(i) / (p(i) - omeps*es(i))
+     end if
+  end do
+
+end function wv_sat_svp_to_qsat_vec
+
+! Get saturation mass mixing ratio (over dry air) given pressure and SVP.
+! Output is limited to the range 0-epsilo.
+elemental function wv_sat_svp_to_qmmr(es, p) result(qs)
+
+  real(rk), intent(in) :: es  ! SVP
+  real(rk), intent(in) :: p   ! Current pressure
+  real(rk) :: qs
+
+  ! If pressure is less than SVP, set qs to maximum of 1.
+  if ( (p - es) <= es ) then
+     qs = epsilo
+  else
+     qs = epsilo*es / (p - es)
+  end if
+
+end function wv_sat_svp_to_qmmr
+
+pure function wv_sat_svp_to_qmmr_vec(n, es, p) result(qs)
+
+  integer,  intent(in) :: n      ! Size of input arrays
+  real(rk), intent(in) :: es(n)  ! SVP
+  real(rk), intent(in) :: p(n)   ! Current pressure
+  real(rk) :: qs(n)
+
+  integer :: i
+
+  ! If pressure is less than SVP, set qs to maximum of 1.
+  do i = 1, n
+     if ( (p(i) - es(i)) <= es(i) ) then
+        qs(i) = epsilo
+     else
+        qs(i) = epsilo*es(i) / (p(i) - es(i))
+     end if
+  end do
+
+end function wv_sat_svp_to_qmmr_vec
+
+elemental subroutine wv_sat_qsat_liquid(t, p, es, qs, idx)
+  !------------------------------------------------------------------!
+  ! Purpose:                                                         !
+  !   Calculate SVP over water at a given temperature, and then      !
+  !   calculate and return saturation specific humidity.             !
+  !------------------------------------------------------------------!
+
+  ! Inputs
+  real(rk), intent(in) :: t    ! Temperature
+  real(rk), intent(in) :: p    ! Pressure
+  ! Outputs
+  real(rk), intent(out) :: es  ! Saturation vapor pressure
+  real(rk), intent(out) :: qs  ! Saturation specific humidity
+
+  integer,  intent(in), optional :: idx ! Scheme index
+
+  es = wv_sat_svp_liquid(t, idx)
+
+  qs = wv_sat_svp_to_qsat(es, p)
+
+  ! Ensures returned es is consistent with limiters on qs.
+  es = min(es, p)
+
+end subroutine wv_sat_qsat_liquid
+
+pure subroutine wv_sat_qsat_liquid_vec(n, t, p, es, qs, idx)
+  !------------------------------------------------------------------!
+  ! Purpose:                                                         !
+  !   Calculate SVP over water at a given temperature, and then      !
+  !   calculate and return saturation specific humidity.             !
+  !------------------------------------------------------------------!
+
+  ! Inputs
+  integer,  intent(in) :: n       ! Size of input arrays
+  real(rk), intent(in) :: t(n)    ! Temperature
+  real(rk), intent(in) :: p(n)    ! Pressure
+  ! Outputs
+  real(rk), intent(out) :: es(n)  ! Saturation vapor pressure
+  real(rk), intent(out) :: qs(n)  ! Saturation specific humidity
+
+  integer,  intent(in), optional :: idx ! Scheme index
+
+  es = wv_sat_svp_liquid(n, t, idx)
+
+  qs = wv_sat_svp_to_qsat(n, es, p)
+
+  ! Ensures returned es is consistent with limiters on qs.
+  es = min(es, p)
+
+end subroutine wv_sat_qsat_liquid_vec
+
+elemental subroutine wv_sat_qsat_ice(t, p, es, qs, idx)
+  !------------------------------------------------------------------!
+  ! Purpose:                                                         !
+  !   Calculate SVP over ice at a given temperature, and then        !
+  !   calculate and return saturation specific humidity.             !
+  !------------------------------------------------------------------!
+
+  ! Inputs
+  real(rk), intent(in) :: t    ! Temperature
+  real(rk), intent(in) :: p    ! Pressure
+  ! Outputs
+  real(rk), intent(out) :: es  ! Saturation vapor pressure
+  real(rk), intent(out) :: qs  ! Saturation specific humidity
+
+  integer,  intent(in), optional :: idx ! Scheme index
+
+  es = wv_sat_svp_ice(t, idx)
+
+  qs = wv_sat_svp_to_qsat(es, p)
+
+  ! Ensures returned es is consistent with limiters on qs.
+  es = min(es, p)
+
+end subroutine wv_sat_qsat_ice
+
+pure subroutine wv_sat_qsat_ice_vec(n, t, p, es, qs, idx)
+  !------------------------------------------------------------------!
+  ! Purpose:                                                         !
+  !   Calculate SVP over ice at a given temperature, and then        !
+  !   calculate and return saturation specific humidity.             !
+  !------------------------------------------------------------------!
+
+  ! Inputs
+  integer,  intent(in) :: n       ! Size of input arrays
+  real(rk), intent(in) :: t(n)    ! Temperature
+  real(rk), intent(in) :: p(n)    ! Pressure
+  ! Outputs
+  real(rk), intent(out) :: es(n)  ! Saturation vapor pressure
+  real(rk), intent(out) :: qs(n)  ! Saturation specific humidity
+
+  integer,  intent(in), optional :: idx ! Scheme index
+
+  es = wv_sat_svp_ice(n, t, idx)
+
+  qs = wv_sat_svp_to_qsat(n, es, p)
+
+  ! Ensures returned es is consistent with limiters on qs.
+  es = min(es, p)
+
+end subroutine wv_sat_qsat_ice_vec
+
+elemental subroutine wv_sat_qsat_mixed(t, p, es, qs, idx)
+  !------------------------------------------------------------------!
+  ! Purpose:                                                         !
+  !   Calculate SVP over ice at a given temperature, and then        !
+  !   calculate and return saturation specific humidity.             !
+  !------------------------------------------------------------------!
+
+  ! Inputs
+  real(rk), intent(in) :: t    ! Temperature
+  real(rk), intent(in) :: p    ! Pressure
+  ! Outputs
+  real(rk), intent(out) :: es  ! Saturation vapor pressure
+  real(rk), intent(out) :: qs  ! Saturation specific humidity
+
+  integer,  intent(in), optional :: idx ! Scheme index
+
+  es = wv_sat_svp_mixed(t, idx)
+
+  qs = wv_sat_svp_to_qsat(es, p)
+
+  ! Ensures returned es is consistent with limiters on qs.
+  es = min(es, p)
+
+end subroutine wv_sat_qsat_mixed
+
+pure subroutine wv_sat_qsat_mixed_vec(n, t, p, es, qs, idx)
+  !------------------------------------------------------------------!
+  ! Purpose:                                                         !
+  !   Calculate SVP over ice at a given temperature, and then        !
+  !   calculate and return saturation specific humidity.             !
+  !------------------------------------------------------------------!
+
+  ! Inputs
+  integer,  intent(in) :: n       ! Size of input arrays
+  real(rk), intent(in) :: t(n)    ! Temperature
+  real(rk), intent(in) :: p(n)    ! Pressure
+  ! Outputs
+  real(rk), intent(out) :: es(n)  ! Saturation vapor pressure
+  real(rk), intent(out) :: qs(n)  ! Saturation specific humidity
+
+  integer,  intent(in), optional :: idx ! Scheme index
+
+  es = wv_sat_svp_mixed(n, t, idx)
+
+  qs = wv_sat_svp_to_qsat(n, es, p)
+
+  ! Ensures returned es is consistent with limiters on qs.
+  es = min(es, p)
+
+end subroutine wv_sat_qsat_mixed_vec
+
+!---------------------------------------------------------------------
+! SVP INTERFACE FUNCTIONS
+!---------------------------------------------------------------------
+
+elemental function wv_sat_svp_liquid(t, idx) result(es)
+  real(rk), intent(in) :: t
+  integer,  intent(in), optional :: idx
+  real(rk) :: es
+
+  integer :: use_idx
+
+  if (present(idx)) then
+     use_idx = idx
+  else
+     use_idx = default_idx
+  end if
+
+  if (use_idx == default_idx .and. allocated(liquid_table)) then
+     es = lookup_svp_in_table(t, liquid_table_spec, liquid_table, &
+          wv_sat_svp_liquid_no_table)
+  else
+     es = wv_sat_svp_liquid_no_table(t, use_idx)
+  end if
+
+end function wv_sat_svp_liquid
+
+pure function wv_sat_svp_liquid_vec(n, t, idx) result(es)
+  integer,  intent(in) :: n
+  real(rk), intent(in) :: t(n)
+  integer,  intent(in), optional :: idx
+  real(rk) :: es(n)
+
+  integer :: use_idx
+  integer :: i
+
+  if (present(idx)) then
+     use_idx = idx
+  else
+     use_idx = default_idx
+  end if
+
+  if (use_idx == default_idx .and. allocated(liquid_table)) then
+     do i = 1, n
+        es(i) = lookup_svp_in_table(t(i), liquid_table_spec, liquid_table, &
+             wv_sat_svp_liquid_no_table)
+     end do
+  else
+     do i = 1, n
+        es(i) = wv_sat_svp_liquid_no_table(t(i), use_idx)
+     end do
+  end if
+
+end function wv_sat_svp_liquid_vec
+
+pure function wv_sat_svp_liquid_no_table(t, idx) result(es)
+  real(rk), intent(in) :: t
+  integer,  intent(in) :: idx
+  real(rk) :: es
+
+  select case (idx)
+  case(GoffGratch_idx)
+     es = GoffGratch_svp_liquid(t)
+  case(MurphyKoop_idx)
+     es = MurphyKoop_svp_liquid(t)
+  case(Bolton_idx)
+     es = Bolton_svp_liquid(t)
+  case (Flatau_idx)
+     es = Flatau_svp_liquid(t)
+  case default
+     ! Providing a correct index is an important precondition for these
+     ! functions. Since we don't have a way of signaling an error, produce an
+     ! obviously unreasonable answer.
+     es = -huge(1._rk)
+  end select
+
+end function wv_sat_svp_liquid_no_table
+
+elemental function wv_sat_svp_ice(t, idx) result(es)
+  real(rk), intent(in) :: t
+  integer,  intent(in), optional :: idx
+  real(rk) :: es
+
+  integer :: use_idx
+
+  if (present(idx)) then
+     use_idx = idx
+  else
+     use_idx = default_idx
+  end if
+
+  if (use_idx == default_idx .and. allocated(ice_table)) then
+     es = lookup_svp_in_table(t, ice_table_spec, ice_table, &
+          wv_sat_svp_ice_no_table)
+  else
+     es = wv_sat_svp_ice_no_table(t, use_idx)
+  end if
+
+end function wv_sat_svp_ice
+
+pure function wv_sat_svp_ice_vec(n, t, idx) result(es)
+  integer,  intent(in) :: n
+  real(rk), intent(in) :: t(n)
+  integer,  intent(in), optional :: idx
+  real(rk) :: es(n)
+
+  integer :: use_idx
+  integer :: i
+
+  if (present(idx)) then
+     use_idx = idx
+  else
+     use_idx = default_idx
+  end if
+
+  if (use_idx == default_idx .and. allocated(ice_table)) then
+     do i = 1, n
+        es(i) = lookup_svp_in_table(t(i), ice_table_spec, ice_table, &
+             wv_sat_svp_ice_no_table)
+     end do
+  else
+     do i = 1, n
+        es(i) = wv_sat_svp_ice_no_table(t(i), use_idx)
+     end do
+  end if
+
+end function wv_sat_svp_ice_vec
+
+pure function wv_sat_svp_ice_no_table(t, idx) result(es)
+  real(rk), intent(in) :: t
+  integer,  intent(in) :: idx
+  real(rk) :: es
+
+  select case (idx)
+  case(GoffGratch_idx)
+     es = GoffGratch_svp_ice(t)
+  case(MurphyKoop_idx)
+     es = MurphyKoop_svp_ice(t)
+  case(Bolton_idx)
+     es = Bolton_svp_ice(t)
+  case (Flatau_idx)
+     es = Flatau_svp_ice(t)
+  case default
+     ! Providing a correct index is an important precondition for these
+     ! functions. Since we don't have a way of signaling an error, produce an
+     ! obviously unreasonable answer.
+     es = -huge(1._rk)
+  end select
+
+end function wv_sat_svp_ice_no_table
+
+elemental function wv_sat_svp_mixed(t, idx) result (es)
+
+  real(rk), intent(in) :: t
+  integer,  intent(in), optional :: idx
+
+  real(rk) :: es
+
+  integer :: use_idx
+
+  if (present(idx)) then
+     use_idx = idx
+  else
+     use_idx = default_idx
+  end if
+
+  if (use_idx == default_idx .and. allocated(mixed_table)) then
+     es = lookup_svp_in_table(t, mixed_table_spec, mixed_table, &
+          wv_sat_svp_mixed_no_table)
+  else
+     es = wv_sat_svp_mixed_no_table(t, use_idx)
+  end if
+
+end function wv_sat_svp_mixed
+
+pure function wv_sat_svp_mixed_vec(n, t, idx) result (es)
+  integer,  intent(in) :: n
+  real(rk), intent(in) :: t(n)
+  integer,  intent(in), optional :: idx
+
+  real(rk) :: es(n)
+
+  integer :: use_idx
+  integer :: i
+
+  if (present(idx)) then
+     use_idx = idx
+  else
+     use_idx = default_idx
+  end if
+
+  if (use_idx == default_idx .and. allocated(mixed_table)) then
+     do i = 1, n
+        es(i) = lookup_svp_in_table(t(i), mixed_table_spec, mixed_table, &
+             wv_sat_svp_mixed_no_table)
+     end do
+  else
+     es = wv_sat_svp_mixed_no_table_vec(n, t, use_idx)
+  end if
+
+end function wv_sat_svp_mixed_vec
+
+pure function wv_sat_svp_mixed_no_table(t, idx) result (es)
+
+  real(rk), intent(in) :: t
+  integer,  intent(in) :: idx
+
+  real(rk) :: es
+
+  real(rk) :: esice      ! Saturation vapor pressure over ice
+  real(rk) :: weight     ! Intermediate scratch variable for es transition
+
+!
+! Water
+!
+  if (t >= (tmelt - ttrice)) then
+     es = wv_sat_svp_liquid(t,idx)
+  else
+     es = 0.0_rk
+  end if
+
+!
+! Ice
+!
+  if (t < tmelt) then
+
+     esice = wv_sat_svp_ice(t,idx)
+
+     if ( (tmelt - t) > ttrice ) then
+        weight = 1.0_rk
+     else
+        weight = (tmelt - t)/ttrice
+     end if
+
+     es = weight*esice + (1.0_rk - weight)*es
+  end if
+
+end function wv_sat_svp_mixed_no_table
+
+! The reason why we need a separate vector version for this function (but
+! not the other "no_table" functions) is that even if the functions called
+! are all inlined, we may still have a table lookup for the liquid/ice
+! tables (rather than the mixed-phase one). That table lookup is not
+! vectorizable, meaning that the above function can't vectorize.
+!
+! Cripes this is ugly, though.
+pure function wv_sat_svp_mixed_no_table_vec(n, t, idx) result (es)
+
+  integer,  intent(in) :: n
+  real(rk), intent(in) :: t(n)
+  integer,  intent(in) :: idx
+
+  real(rk) :: es(n)
+
+  real(rk) :: esice      ! Saturation vapor pressure over ice
+  real(rk) :: weight     ! Intermediate scratch variable for es transition
+
+  integer :: i
+
+!
+! Water
+!
+  if (idx == default_idx .and. allocated(liquid_table)) then
+     do i = 1, n
+        if (t(i) >= (tmelt - ttrice)) then
+           es(i) = lookup_svp_in_table(t(i), liquid_table_spec, liquid_table, &
+                wv_sat_svp_liquid_no_table)
+        else
+           es(i) = 0.0_rk
+        end if
+     end do
+  else
+     do i = 1, n
+        if (t(i) >= (tmelt - ttrice)) then
+           es(i) = wv_sat_svp_liquid_no_table(t(i), idx)
+        else
+           es(i) = 0.0_rk
+        end if
+     end do
+  end if
+
+!
+! Ice
+!
+  if (idx == default_idx .and. allocated(ice_table)) then
+     do i = 1, n
+        if (t(i) < tmelt) then
+           esice = lookup_svp_in_table(t(i), ice_table_spec, ice_table, &
+                wv_sat_svp_ice_no_table)
+
+           if ( (tmelt - t(i)) > ttrice ) then
+              weight = 1.0_rk
+           else
+              weight = (tmelt - t(i))/ttrice
+           end if
+
+           es(i) = weight*esice + (1.0_rk - weight)*es(i)
+        end if
+     end do
+  else
+     do i = 1, n
+        if (t(i) < tmelt) then
+           esice = wv_sat_svp_ice_no_table(t(i), idx)
+
+           if ( (tmelt - t(i)) > ttrice ) then
+              weight = 1.0_rk
+           else
+              weight = (tmelt - t(i))/ttrice
+           end if
+
+           es(i) = weight*esice + (1.0_rk - weight)*es(i)
+        end if
+     end do
+  end if
+
+end function wv_sat_svp_mixed_no_table_vec
+
+!---------------------------------------------------------------------
+! SVP METHODS
+!---------------------------------------------------------------------
+
+! Use the lookup table
+! Note that a function that takes a procedure argument can't be elemental, but
+! it must be pure to be called from the elemental interfaces above.
+recursive pure function lookup_svp_in_table(t, table_spec, table, fallback) &
+     result(es)
+  ! Temperature in Kelvin
+  real(rk), intent(in) :: t
+  ! Table range specification
+  type(WVSatTableSpec), intent(in) :: table_spec
+  ! The table itself
+  real(rk), intent(in) :: table(table_spec%table_size)
+  ! Fallback used when we're outside the table bounds
+  interface
+     pure function fallback(t, idx) result(es)
+       import :: rk
+       real(rk), intent(in) :: t
+       integer, intent(in) :: idx
+       real(rk) :: es
+     end function fallback
+  end interface
+  ! SVP in Pa
+  real(rk) :: es
+
+  integer :: idx
+  real(rk) :: residual
+
+  residual = (t - table_spec%minimum)/table_spec%spacing + 1._rk
+  idx = int(residual)
+  ! Deal with the case where we're outside the table bounds.
+  if (idx < 1 .or. idx+1 > table_spec%table_size) then
+     es = fallback(t, default_idx)
+     return
+  end if
+
+  ! Now we want the "residual" to be how far this temperature is past the
+  ! current index.
+  residual = residual - real(idx, rk)
+
+  ! Just use linear interpolation. Some iterative methods might do better if we
+  ! used a cubic.
+  es = table(idx) * (1._rk-residual) + table(idx+1) * residual
+
+end function lookup_svp_in_table
+
+! Goff & Gratch (1946)
+
+pure function GoffGratch_svp_liquid(t) result(es)
+  real(rk), intent(in) :: t  ! Temperature in Kelvin
+  real(rk) :: es             ! SVP in Pa
+
+  ! uncertain below -70 C
+  es = 10._rk**(-7.90298_rk*(tboil/t-1._rk)+ &
+       5.02808_rk*log10(tboil/t)- &
+       1.3816e-7_rk*(10._rk**(11.344_rk*(1._rk-t/tboil))-1._rk)+ &
+       8.1328e-3_rk*(10._rk**(-3.49149_rk*(tboil/t-1._rk))-1._rk)+ &
+       log10(1013.246_rk))*100._rk
+
+end function GoffGratch_svp_liquid
+
+pure function GoffGratch_svp_ice(t) result(es)
+  real(rk), intent(in) :: t  ! Temperature in Kelvin
+  real(rk) :: es             ! SVP in Pa
+
+  ! good down to -100 C
+  es = 10._rk**(-9.09718_rk*(h2otrip/t-1._rk)-3.56654_rk* &
+       log10(h2otrip/t)+0.876793_rk*(1._rk-t/h2otrip)+ &
+       log10(6.1071_rk))*100._rk
+
+end function GoffGratch_svp_ice
+
+! Murphy & Koop (2005)
+
+pure function MurphyKoop_svp_liquid(t) result(es)
+  real(rk), intent(in) :: t  ! Temperature in Kelvin
+  real(rk) :: es             ! SVP in Pa
+
+  ! (good for 123 < T < 332 K)
+  es = exp(54.842763_rk - (6763.22_rk / t) - (4.210_rk * log(t)) + &
+       (0.000367_rk * t) + (tanh(0.0415_rk * (t - 218.8_rk)) * &
+       (53.878_rk - (1331.22_rk / t) - (9.44523_rk * log(t)) + &
+       0.014025_rk * t)))
+
+end function MurphyKoop_svp_liquid
+
+pure function MurphyKoop_svp_ice(t) result(es)
+  real(rk), intent(in) :: t  ! Temperature in Kelvin
+  real(rk) :: es             ! SVP in Pa
+
+  ! (good down to 110 K)
+  es = exp(9.550426_rk - (5723.265_rk / t) + (3.53068_rk * log(t)) &
+       - (0.00728332_rk * t))
+
+end function MurphyKoop_svp_ice
+
+! Taken from CLUBB, based on Bolton (1980).
+
+pure function Bolton_svp_liquid(t) result(es)
+  real(rk), parameter :: c1 = 611.2_rk
+  real(rk), parameter :: c2 = 17.67_rk
+  real(rk), parameter :: c3 = 29.65_rk
+
+  real(rk), intent(in) :: t  ! Temperature in Kelvin
+  real(rk) :: es             ! SVP in Pa
+
+  es = c1*exp( (c2*(t - tmelt))/(t - c3) )
+
+end function Bolton_svp_liquid
+
+pure function Bolton_svp_ice(t) result(es)
+
+  real(rk), intent(in) :: t  ! Temperature in Kelvin
+  real(rk) :: es             ! SVP in Pa
+
+  es = exp( 27.93603_rk - (6111.72784_rk/t) + (0.15215_rk*log(t)) )
+
+end function Bolton_svp_ice
+
+! "Flatau" scheme modified from CLUBB, based on:
+!
+! ``Polynomial Fits to Saturation Vapor Pressure'' Falatau, Walko,
+!   and Cotton.  (1992)  Journal of Applied Meteorology, Vol. 31,
+!   pp. 1507--1513
+
+pure function Flatau_svp_liquid(t) result(es)
+
+  real(rk), intent(in) :: t  ! Temperature in Kelvin
+  real(rk) :: es             ! SVP in Pa
+
+  real(rk), dimension(9), parameter :: coef = [ &
+       6.11583699E+02_rk, 4.44606896E+01_rk, 1.43177157E+00_rk, &
+       2.64224321E-02_rk, 2.99291081E-04_rk, 2.03154182E-06_rk, &
+       7.02620698E-09_rk, 3.79534310E-12_rk,-3.21582393E-14_rk ]
+
+  real(rk), parameter :: min_T_in_C = -85._rk
+
+  real(rk) :: T_in_C
+
+  T_in_C = max(t - tmelt, min_T_in_C)
+
+  es = coef(1) + T_in_C * (coef(2) + T_in_C * (coef(3) + T_in_C * &
+       (coef(4) + T_in_C * (coef(5) + T_in_C * (coef(6) + T_in_C * &
+       (coef(7) + T_in_C * (coef(8) + T_in_C * coef(9))))))))
+
+end function Flatau_svp_liquid
+
+pure function Flatau_svp_ice(t) result(es)
+
+  real(rk), intent(in) :: t  ! Temperature in Kelvin
+  real(rk) :: es             ! SVP in Pa
+
+  real(rk), dimension(9), parameter :: coef = [ &
+       6.09868993E+02_rk, 4.99320233E+01_rk, 1.84672631E+00_rk, &
+       4.02737184E-02_rk, 5.65392987E-04_rk, 5.21693933E-06_rk, &
+       3.07839583E-08_rk, 1.05785160E-10_rk, 1.61444444E-13_rk ]
+
+  real(rk), parameter :: min_T_in_C = -90._rk
+
+  real(rk) :: T_in_C
+
+  T_in_C = max(t - tmelt, min_T_in_C)
+
+  es = coef(1) + T_in_C * (coef(2) + T_in_C * (coef(3) + T_in_C * &
+       (coef(4) + T_in_C * (coef(5) + T_in_C * (coef(6) + T_in_C * &
+       (coef(7) + T_in_C * (coef(8) + T_in_C * coef(9))))))))
+
+end function Flatau_svp_ice
+
+end module shr_wv_sat_mod

--- a/share/csm_share/test/unit/CMakeLists.txt
+++ b/share/csm_share/test/unit/CMakeLists.txt
@@ -13,3 +13,5 @@ add_subdirectory(shr_log_test)
 add_subdirectory(dynamic_vector)
 
 add_subdirectory(shr_vmath_test)
+
+add_subdirectory(shr_wv_sat_test)

--- a/share/csm_share/test/unit/shr_wv_sat_test/CMakeLists.txt
+++ b/share/csm_share/test/unit/shr_wv_sat_test/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Local pFUnit files.
+set(pf_sources
+  test_wv_sat.pf test_wv_sat_each_method.pf)
+
+# Sources to test.
+set(sources_needed
+  shr_kind_mod.F90 shr_const_mod.F90 shr_wv_sat_mod.F90)
+extract_sources("${sources_needed}" "${share_sources}" test_sources)
+
+# Do source preprocessing and add the executable.
+create_pFUnit_test(shr_wv_sat_mod shr_wv_sat_mod_exe "${pf_sources}"
+  "${test_sources}")

--- a/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat.pf
+++ b/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat.pf
@@ -1,0 +1,243 @@
+module test_wv_sat
+
+use pfunit_mod
+
+use shr_kind_mod, only: r8 => shr_kind_r8
+use shr_const_mod, only: &
+     tmelt => shr_const_tkfrz, &
+     h2otrip => shr_const_tktrip, &
+     mwwv => shr_const_mwwv, &
+     mwdair => shr_const_mwdair
+use shr_wv_sat_mod
+
+implicit none
+public
+
+real(r8), parameter :: tboil = 373.16_r8
+real(r8), parameter :: t_transition = 20._r8
+real(r8), parameter :: epsilo = mwwv/mwdair
+
+contains
+
+@Before
+subroutine setUp()
+
+  character(len=128) :: errstring
+
+  call wv_sat_init(tmelt, h2otrip, tboil, t_transition, epsilo, &
+       errstring)
+
+  if (errstring /= "") then
+     call throw("Error from wv_sat_init: "//trim(errstring))
+  end if
+
+end subroutine setUp
+
+@After
+subroutine tearDown()
+  call wv_sat_final()
+end subroutine tearDown
+
+@Test
+subroutine invalid_name_produces_invalid_index()
+
+  integer :: idx
+
+  idx = wv_sat_get_scheme_idx("NotARealSaturationSchemeName")
+  @assertTrue(.not. wv_sat_valid_idx(idx))
+
+end subroutine invalid_name_produces_invalid_index
+
+@Test
+subroutine qsat_not_greater_than_one()
+
+  ! Even if the SVP is greater the current pressure, the saturation specific
+  ! humidity returned should be capped at 1.
+  @assertEqual(1.0_r8, wv_sat_svp_to_qsat(1.0_r8, 0.5_r8))
+  @assertEqual(1.0_r8, wv_sat_svp_to_qsat(2, [1.0_r8, 2.0_r8], [0.5_r8, 0.5_r8]))
+
+end subroutine qsat_not_greater_than_one
+
+@Test
+subroutine qmmr_not_greater_than_epsilon()
+
+  integer, parameter :: n = 3
+  real(r8), parameter :: es(n) = [0.51_r8, 1.0_r8, 1.5_r8]
+  real(r8), parameter :: p(n) = [1.0_r8, 1.0_r8, 1.0_r8]
+
+  integer :: i
+
+  ! As SVP becomes close to the actual pressure, the mass mixing ratio goes to
+  ! infinity, so check that we actually cap it at epsilon once the SVP is more
+  ! than half the total pressure.
+  do i = 1, 3
+     @assertEqual(epsilo, wv_sat_svp_to_qmmr(es(i), p(i)))
+  end do
+  @assertEqual(epsilo, wv_sat_svp_to_qmmr(n, es, p))
+
+end subroutine qmmr_not_greater_than_epsilon
+
+@Test
+subroutine esat_not_greater_than_p()
+
+  real(r8) :: es, qs
+  real(r8) :: es_vec(1), qs_vec(1)
+
+  ! For the combined routine, we don't allow the SVP to exceed the current
+  ! pressure. Tested here by simply providing an extremely low pressure.
+
+  ! This is a guard against schemes that "blindly" attempt to reach saturation
+  ! by evaporating cloud water, no matter what the conditions. At very low
+  ! pressures this is impossible, so we return a limited value to prevent
+  ! numerical issues.
+
+  call wv_sat_qsat_liquid(280._r8, 1.e-30_r8, es, qs)
+  @assertEqual(1.e-30_r8, es)
+
+  call wv_sat_qsat_liquid(1, [280._r8], [1.e-30_r8], es_vec, qs_vec)
+  @assertEqual([1.e-30_r8], es_vec)
+
+  call wv_sat_qsat_ice(260._r8, 1.e-30_r8, es, qs)
+  @assertEqual(1.e-30_r8, es)
+
+  call wv_sat_qsat_ice(1, [260._r8], [1.e-30_r8], es_vec, qs_vec)
+  @assertEqual([1.e-30_r8], es_vec)
+
+  call wv_sat_qsat_mixed(270._r8, 1.e-30_r8, es, qs)
+  @assertEqual(1.e-30_r8, es)
+
+  call wv_sat_qsat_mixed(1, [270._r8], [1.e-30_r8], es_vec, qs_vec)
+  @assertEqual([1.e-30_r8], es_vec)
+
+end subroutine esat_not_greater_than_p
+
+@Test
+subroutine liquid_vapor_table_is_used()
+  type(WVSatTableSpec) :: liquid_table_spec
+
+  real(r8) :: non_table_value
+  real(r8) :: table_value
+
+  non_table_value = wv_sat_svp_liquid(tmelt+7.5_r8)
+
+  liquid_table_spec = WVSatTableSpec(151, tmelt-50._r8, 1._r8)
+  call wv_sat_make_tables(liquid_spec_in=liquid_table_spec)
+
+  table_value = wv_sat_svp_liquid(tmelt+7.5_r8)
+
+  ! We can't really see directly whether the table is used, but we can pick a
+  ! value that requires interpolation and look for the difference.
+  @assertFalse(non_table_value == table_value)
+
+end subroutine liquid_vapor_table_is_used
+
+@Test
+subroutine liquid_vapor_table_not_extrapolated()
+  type(WVSatTableSpec) :: liquid_table_spec
+
+  real(r8) :: non_table_low_value, non_table_high_value
+  real(r8) :: table_low_value, table_high_value
+
+  non_table_low_value = wv_sat_svp_liquid(tmelt-50.5_r8)
+  non_table_high_value = wv_sat_svp_liquid(tmelt+150.5_r8)
+
+  liquid_table_spec = WVSatTableSpec(151, tmelt-50._r8, 1._r8)
+  call wv_sat_make_tables(liquid_spec_in=liquid_table_spec)
+
+  table_low_value = wv_sat_svp_liquid(tmelt-50.5_r8)
+  table_high_value = wv_sat_svp_liquid(tmelt+150.5_r8)
+
+  ! Beyond the table boundaries, the lookup table should not be used, and so we
+  ! should get the same answer as before specifying any tables.
+  @assertEqual(non_table_low_value, table_low_value)
+  @assertEqual(non_table_high_value, table_high_value)
+
+end subroutine liquid_vapor_table_not_extrapolated
+
+@Test
+subroutine ice_vapor_table_is_used()
+  type(WVSatTableSpec) :: ice_table_spec
+
+  real(r8) :: non_table_value
+  real(r8) :: table_value
+
+  non_table_value = wv_sat_svp_ice(tmelt-7.5_r8)
+
+  ice_table_spec = WVSatTableSpec(106, tmelt-100._r8, 1._r8)
+  call wv_sat_make_tables(ice_spec_in=ice_table_spec)
+
+  table_value = wv_sat_svp_ice(tmelt-7.5_r8)
+
+  ! We can't really see directly whether the table is used, but we can pick a
+  ! value that requires interpolation and look for the difference.
+  @assertFalse(non_table_value == table_value)
+
+end subroutine ice_vapor_table_is_used
+
+@Test
+subroutine ice_vapor_table_not_extrapolated()
+  type(WVSatTableSpec) :: ice_table_spec
+
+  real(r8) :: non_table_low_value, non_table_high_value
+  real(r8) :: table_low_value, table_high_value
+
+  non_table_low_value = wv_sat_svp_ice(tmelt-100.5_r8)
+  non_table_high_value = wv_sat_svp_ice(tmelt+5.5_r8)
+
+  ice_table_spec = WVSatTableSpec(106, tmelt-100._r8, 1._r8)
+  call wv_sat_make_tables(ice_spec_in=ice_table_spec)
+
+  table_low_value = wv_sat_svp_ice(tmelt-100.5_r8)
+  table_high_value = wv_sat_svp_ice(tmelt+5.5_r8)
+
+  ! Beyond the table boundaries, the lookup table should not be used, and so we
+  ! should get the same answer as before specifying any tables.
+  @assertEqual(non_table_low_value, table_low_value)
+  @assertEqual(non_table_high_value, table_high_value)
+
+end subroutine ice_vapor_table_not_extrapolated
+
+@Test
+subroutine mixed_vapor_table_is_used()
+  type(WVSatTableSpec) :: mixed_table_spec
+
+  real(r8) :: non_table_value
+  real(r8) :: table_value
+
+  non_table_value = wv_sat_svp_mixed(tmelt-7.5_r8)
+
+  mixed_table_spec = WVSatTableSpec(201, tmelt-100._r8, 1._r8)
+  call wv_sat_make_tables(mixed_spec_in=mixed_table_spec)
+
+  table_value = wv_sat_svp_mixed(tmelt-7.5_r8)
+
+  ! We can't really see directly whether the table is used, but we can pick a
+  ! value that requires interpolation and look for the difference.
+  @assertFalse(non_table_value == table_value)
+
+end subroutine mixed_vapor_table_is_used
+
+@Test
+subroutine mixed_vapor_table_not_extrapolated()
+  type(WVSatTableSpec) :: mixed_table_spec
+
+  real(r8) :: non_table_low_value, non_table_high_value
+  real(r8) :: table_low_value, table_high_value
+
+  non_table_low_value = wv_sat_svp_mixed(tmelt-100.5_r8)
+  non_table_high_value = wv_sat_svp_mixed(tmelt+100.5_r8)
+
+  mixed_table_spec = WVSatTableSpec(201, tmelt-100._r8, 1._r8)
+  call wv_sat_make_tables(mixed_spec_in=mixed_table_spec)
+
+  table_low_value = wv_sat_svp_mixed(tmelt-100.5_r8)
+  table_high_value = wv_sat_svp_mixed(tmelt+100.5_r8)
+
+  ! Beyond the table boundaries, the lookup table should not be used, and so we
+  ! should get the same answer as before specifying any tables.
+  @assertEqual(non_table_low_value, table_low_value)
+  @assertEqual(non_table_high_value, table_high_value)
+
+end subroutine mixed_vapor_table_not_extrapolated
+
+end module test_wv_sat

--- a/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat.pf
+++ b/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat.pf
@@ -47,6 +47,21 @@ subroutine invalid_name_produces_invalid_index()
 end subroutine invalid_name_produces_invalid_index
 
 @Test
+subroutine reject_out_of_bounds_transition
+
+  character(len=128) :: errstring
+
+  ! Negative transition ranges are meaningless.
+  call wv_sat_init(tmelt, h2otrip, -1._r8, epsilo, errstring)
+  @assertTrue(errstring /= "")
+
+  ! A transition range of 0 is OK.
+  call wv_sat_init(tmelt, h2otrip, 0._r8, epsilo, errstring)
+  @assertTrue(errstring == "")
+
+end subroutine reject_out_of_bounds_transition
+
+@Test
 subroutine qsat_not_greater_than_one()
 
   ! Even if the SVP is greater the current pressure, the saturation specific

--- a/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat.pf
+++ b/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat.pf
@@ -13,7 +13,6 @@ use shr_wv_sat_mod
 implicit none
 public
 
-real(r8), parameter :: tboil = 373.16_r8
 real(r8), parameter :: t_transition = 20._r8
 real(r8), parameter :: epsilo = mwwv/mwdair
 
@@ -24,8 +23,7 @@ subroutine setUp()
 
   character(len=128) :: errstring
 
-  call wv_sat_init(tmelt, h2otrip, tboil, t_transition, epsilo, &
-       errstring)
+  call wv_sat_init(tmelt, h2otrip, t_transition, epsilo, errstring)
 
   if (errstring /= "") then
      call throw("Error from wv_sat_init: "//trim(errstring))

--- a/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat.pf
+++ b/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat.pf
@@ -23,17 +23,17 @@ subroutine setUp()
 
   character(len=128) :: errstring
 
-  call wv_sat_init(tmelt, h2otrip, t_transition, epsilo, errstring)
+  call shr_wv_sat_init(tmelt, h2otrip, t_transition, epsilo, errstring)
 
   if (errstring /= "") then
-     call throw("Error from wv_sat_init: "//trim(errstring))
+     call throw("Error from shr_wv_sat_init: "//trim(errstring))
   end if
 
 end subroutine setUp
 
 @After
 subroutine tearDown()
-  call wv_sat_final()
+  call shr_wv_sat_final()
 end subroutine tearDown
 
 @Test
@@ -41,8 +41,8 @@ subroutine invalid_name_produces_invalid_index()
 
   integer :: idx
 
-  idx = wv_sat_get_scheme_idx("NotARealSaturationSchemeName")
-  @assertTrue(.not. wv_sat_valid_idx(idx))
+  idx = shr_wv_sat_get_scheme_idx("NotARealSaturationSchemeName")
+  @assertTrue(.not. shr_wv_sat_valid_idx(idx))
 
 end subroutine invalid_name_produces_invalid_index
 
@@ -52,11 +52,11 @@ subroutine reject_out_of_bounds_transition
   character(len=128) :: errstring
 
   ! Negative transition ranges are meaningless.
-  call wv_sat_init(tmelt, h2otrip, -1._r8, epsilo, errstring)
+  call shr_wv_sat_init(tmelt, h2otrip, -1._r8, epsilo, errstring)
   @assertTrue(errstring /= "")
 
   ! A transition range of 0 is OK.
-  call wv_sat_init(tmelt, h2otrip, 0._r8, epsilo, errstring)
+  call shr_wv_sat_init(tmelt, h2otrip, 0._r8, epsilo, errstring)
   @assertTrue(errstring == "")
 
 end subroutine reject_out_of_bounds_transition
@@ -66,8 +66,8 @@ subroutine qsat_not_greater_than_one()
 
   ! Even if the SVP is greater the current pressure, the saturation specific
   ! humidity returned should be capped at 1.
-  @assertEqual(1.0_r8, wv_sat_svp_to_qsat(1.0_r8, 0.5_r8))
-  @assertEqual(1.0_r8, wv_sat_svp_to_qsat(2, [1.0_r8, 2.0_r8], [0.5_r8, 0.5_r8]))
+  @assertEqual(1.0_r8, shr_wv_sat_svp_to_qsat(1.0_r8, 0.5_r8))
+  @assertEqual(1.0_r8, shr_wv_sat_svp_to_qsat(2, [1.0_r8, 2.0_r8], [0.5_r8, 0.5_r8]))
 
 end subroutine qsat_not_greater_than_one
 
@@ -84,9 +84,9 @@ subroutine qmmr_not_greater_than_epsilon()
   ! infinity, so check that we actually cap it at epsilon once the SVP is more
   ! than half the total pressure.
   do i = 1, 3
-     @assertEqual(epsilo, wv_sat_svp_to_qmmr(es(i), p(i)))
+     @assertEqual(epsilo, shr_wv_sat_svp_to_qmmr(es(i), p(i)))
   end do
-  @assertEqual(epsilo, wv_sat_svp_to_qmmr(n, es, p))
+  @assertEqual(epsilo, shr_wv_sat_svp_to_qmmr(n, es, p))
 
 end subroutine qmmr_not_greater_than_epsilon
 
@@ -104,39 +104,39 @@ subroutine esat_not_greater_than_p()
   ! pressures this is impossible, so we return a limited value to prevent
   ! numerical issues.
 
-  call wv_sat_qsat_liquid(280._r8, 1.e-30_r8, es, qs)
+  call shr_wv_sat_qsat_liquid(280._r8, 1.e-30_r8, es, qs)
   @assertEqual(1.e-30_r8, es)
 
-  call wv_sat_qsat_liquid(1, [280._r8], [1.e-30_r8], es_vec, qs_vec)
+  call shr_wv_sat_qsat_liquid(1, [280._r8], [1.e-30_r8], es_vec, qs_vec)
   @assertEqual([1.e-30_r8], es_vec)
 
-  call wv_sat_qsat_ice(260._r8, 1.e-30_r8, es, qs)
+  call shr_wv_sat_qsat_ice(260._r8, 1.e-30_r8, es, qs)
   @assertEqual(1.e-30_r8, es)
 
-  call wv_sat_qsat_ice(1, [260._r8], [1.e-30_r8], es_vec, qs_vec)
+  call shr_wv_sat_qsat_ice(1, [260._r8], [1.e-30_r8], es_vec, qs_vec)
   @assertEqual([1.e-30_r8], es_vec)
 
-  call wv_sat_qsat_mixed(270._r8, 1.e-30_r8, es, qs)
+  call shr_wv_sat_qsat_mixed(270._r8, 1.e-30_r8, es, qs)
   @assertEqual(1.e-30_r8, es)
 
-  call wv_sat_qsat_mixed(1, [270._r8], [1.e-30_r8], es_vec, qs_vec)
+  call shr_wv_sat_qsat_mixed(1, [270._r8], [1.e-30_r8], es_vec, qs_vec)
   @assertEqual([1.e-30_r8], es_vec)
 
 end subroutine esat_not_greater_than_p
 
 @Test
 subroutine liquid_vapor_table_is_used()
-  type(WVSatTableSpec) :: liquid_table_spec
+  type(ShrWVSatTableSpec) :: liquid_table_spec
 
   real(r8) :: non_table_value
   real(r8) :: table_value
 
-  non_table_value = wv_sat_svp_liquid(tmelt+7.5_r8)
+  non_table_value = shr_wv_sat_svp_liquid(tmelt+7.5_r8)
 
-  liquid_table_spec = WVSatTableSpec(151, tmelt-50._r8, 1._r8)
-  call wv_sat_make_tables(liquid_spec_in=liquid_table_spec)
+  liquid_table_spec = ShrWVSatTableSpec(151, tmelt-50._r8, 1._r8)
+  call shr_wv_sat_make_tables(liquid_spec_in=liquid_table_spec)
 
-  table_value = wv_sat_svp_liquid(tmelt+7.5_r8)
+  table_value = shr_wv_sat_svp_liquid(tmelt+7.5_r8)
 
   ! We can't really see directly whether the table is used, but we can pick a
   ! value that requires interpolation and look for the difference.
@@ -146,19 +146,19 @@ end subroutine liquid_vapor_table_is_used
 
 @Test
 subroutine liquid_vapor_table_not_extrapolated()
-  type(WVSatTableSpec) :: liquid_table_spec
+  type(ShrWVSatTableSpec) :: liquid_table_spec
 
   real(r8) :: non_table_low_value, non_table_high_value
   real(r8) :: table_low_value, table_high_value
 
-  non_table_low_value = wv_sat_svp_liquid(tmelt-50.5_r8)
-  non_table_high_value = wv_sat_svp_liquid(tmelt+150.5_r8)
+  non_table_low_value = shr_wv_sat_svp_liquid(tmelt-50.5_r8)
+  non_table_high_value = shr_wv_sat_svp_liquid(tmelt+150.5_r8)
 
-  liquid_table_spec = WVSatTableSpec(151, tmelt-50._r8, 1._r8)
-  call wv_sat_make_tables(liquid_spec_in=liquid_table_spec)
+  liquid_table_spec = ShrWVSatTableSpec(151, tmelt-50._r8, 1._r8)
+  call shr_wv_sat_make_tables(liquid_spec_in=liquid_table_spec)
 
-  table_low_value = wv_sat_svp_liquid(tmelt-50.5_r8)
-  table_high_value = wv_sat_svp_liquid(tmelt+150.5_r8)
+  table_low_value = shr_wv_sat_svp_liquid(tmelt-50.5_r8)
+  table_high_value = shr_wv_sat_svp_liquid(tmelt+150.5_r8)
 
   ! Beyond the table boundaries, the lookup table should not be used, and so we
   ! should get the same answer as before specifying any tables.
@@ -169,17 +169,17 @@ end subroutine liquid_vapor_table_not_extrapolated
 
 @Test
 subroutine ice_vapor_table_is_used()
-  type(WVSatTableSpec) :: ice_table_spec
+  type(ShrWVSatTableSpec) :: ice_table_spec
 
   real(r8) :: non_table_value
   real(r8) :: table_value
 
-  non_table_value = wv_sat_svp_ice(tmelt-7.5_r8)
+  non_table_value = shr_wv_sat_svp_ice(tmelt-7.5_r8)
 
-  ice_table_spec = WVSatTableSpec(106, tmelt-100._r8, 1._r8)
-  call wv_sat_make_tables(ice_spec_in=ice_table_spec)
+  ice_table_spec = ShrWVSatTableSpec(106, tmelt-100._r8, 1._r8)
+  call shr_wv_sat_make_tables(ice_spec_in=ice_table_spec)
 
-  table_value = wv_sat_svp_ice(tmelt-7.5_r8)
+  table_value = shr_wv_sat_svp_ice(tmelt-7.5_r8)
 
   ! We can't really see directly whether the table is used, but we can pick a
   ! value that requires interpolation and look for the difference.
@@ -189,19 +189,19 @@ end subroutine ice_vapor_table_is_used
 
 @Test
 subroutine ice_vapor_table_not_extrapolated()
-  type(WVSatTableSpec) :: ice_table_spec
+  type(ShrWVSatTableSpec) :: ice_table_spec
 
   real(r8) :: non_table_low_value, non_table_high_value
   real(r8) :: table_low_value, table_high_value
 
-  non_table_low_value = wv_sat_svp_ice(tmelt-100.5_r8)
-  non_table_high_value = wv_sat_svp_ice(tmelt+5.5_r8)
+  non_table_low_value = shr_wv_sat_svp_ice(tmelt-100.5_r8)
+  non_table_high_value = shr_wv_sat_svp_ice(tmelt+5.5_r8)
 
-  ice_table_spec = WVSatTableSpec(106, tmelt-100._r8, 1._r8)
-  call wv_sat_make_tables(ice_spec_in=ice_table_spec)
+  ice_table_spec = ShrWVSatTableSpec(106, tmelt-100._r8, 1._r8)
+  call shr_wv_sat_make_tables(ice_spec_in=ice_table_spec)
 
-  table_low_value = wv_sat_svp_ice(tmelt-100.5_r8)
-  table_high_value = wv_sat_svp_ice(tmelt+5.5_r8)
+  table_low_value = shr_wv_sat_svp_ice(tmelt-100.5_r8)
+  table_high_value = shr_wv_sat_svp_ice(tmelt+5.5_r8)
 
   ! Beyond the table boundaries, the lookup table should not be used, and so we
   ! should get the same answer as before specifying any tables.
@@ -212,17 +212,17 @@ end subroutine ice_vapor_table_not_extrapolated
 
 @Test
 subroutine mixed_vapor_table_is_used()
-  type(WVSatTableSpec) :: mixed_table_spec
+  type(ShrWVSatTableSpec) :: mixed_table_spec
 
   real(r8) :: non_table_value
   real(r8) :: table_value
 
-  non_table_value = wv_sat_svp_mixed(tmelt-7.5_r8)
+  non_table_value = shr_wv_sat_svp_mixed(tmelt-7.5_r8)
 
-  mixed_table_spec = WVSatTableSpec(201, tmelt-100._r8, 1._r8)
-  call wv_sat_make_tables(mixed_spec_in=mixed_table_spec)
+  mixed_table_spec = ShrWVSatTableSpec(201, tmelt-100._r8, 1._r8)
+  call shr_wv_sat_make_tables(mixed_spec_in=mixed_table_spec)
 
-  table_value = wv_sat_svp_mixed(tmelt-7.5_r8)
+  table_value = shr_wv_sat_svp_mixed(tmelt-7.5_r8)
 
   ! We can't really see directly whether the table is used, but we can pick a
   ! value that requires interpolation and look for the difference.
@@ -232,19 +232,19 @@ end subroutine mixed_vapor_table_is_used
 
 @Test
 subroutine mixed_vapor_table_not_extrapolated()
-  type(WVSatTableSpec) :: mixed_table_spec
+  type(ShrWVSatTableSpec) :: mixed_table_spec
 
   real(r8) :: non_table_low_value, non_table_high_value
   real(r8) :: table_low_value, table_high_value
 
-  non_table_low_value = wv_sat_svp_mixed(tmelt-100.5_r8)
-  non_table_high_value = wv_sat_svp_mixed(tmelt+100.5_r8)
+  non_table_low_value = shr_wv_sat_svp_mixed(tmelt-100.5_r8)
+  non_table_high_value = shr_wv_sat_svp_mixed(tmelt+100.5_r8)
 
-  mixed_table_spec = WVSatTableSpec(201, tmelt-100._r8, 1._r8)
-  call wv_sat_make_tables(mixed_spec_in=mixed_table_spec)
+  mixed_table_spec = ShrWVSatTableSpec(201, tmelt-100._r8, 1._r8)
+  call shr_wv_sat_make_tables(mixed_spec_in=mixed_table_spec)
 
-  table_low_value = wv_sat_svp_mixed(tmelt-100.5_r8)
-  table_high_value = wv_sat_svp_mixed(tmelt+100.5_r8)
+  table_low_value = shr_wv_sat_svp_mixed(tmelt-100.5_r8)
+  table_high_value = shr_wv_sat_svp_mixed(tmelt+100.5_r8)
 
   ! Beyond the table boundaries, the lookup table should not be used, and so we
   ! should get the same answer as before specifying any tables.

--- a/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat_each_method.pf
+++ b/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat_each_method.pf
@@ -76,21 +76,21 @@ subroutine setUp(this)
 
   character(len=128) :: errstring
 
-  type(WVSatTableSpec) :: liquid_table_spec, ice_table_spec, mixed_table_spec
+  type(ShrWVSatTableSpec) :: liquid_table_spec, ice_table_spec, mixed_table_spec
 
-  call wv_sat_init(tmelt, h2otrip, t_transition, epsilo, errstring)
+  call shr_wv_sat_init(tmelt, h2otrip, t_transition, epsilo, errstring)
 
   if (errstring /= "") then
-     call throw("Error from wv_sat_init: "//trim(errstring))
+     call throw("Error from shr_wv_sat_init: "//trim(errstring))
   end if
 
-  @assertTrue(wv_sat_set_default(this%scheme_name))
+  @assertTrue(shr_wv_sat_set_default(this%scheme_name))
 
   if (this%make_table) then
-     liquid_table_spec = WVSatTableSpec(151, tmelt-50._r8, 1._r8)
-     ice_table_spec = WVSatTableSpec(106, tmelt-100._r8, 1._r8)
-     mixed_table_spec = WVSatTableSpec(201, tmelt-100._r8, 1._r8)
-     call wv_sat_make_tables(&
+     liquid_table_spec = ShrWVSatTableSpec(151, tmelt-50._r8, 1._r8)
+     ice_table_spec = ShrWVSatTableSpec(106, tmelt-100._r8, 1._r8)
+     mixed_table_spec = ShrWVSatTableSpec(201, tmelt-100._r8, 1._r8)
+     call shr_wv_sat_make_tables(&
           liquid_spec_in=liquid_table_spec, &
           ice_spec_in=ice_table_spec, &
           mixed_spec_in=mixed_table_spec)
@@ -102,7 +102,7 @@ subroutine tearDown(this)
 
   class(WVSchemeCase), intent(inout) :: this
 
-  call wv_sat_final()
+  call shr_wv_sat_final()
 
 end subroutine tearDown
 
@@ -129,10 +129,10 @@ subroutine scheme_has_correct_ice_trip_point(this)
   class(WVSchemeCase), intent(inout) :: this
 
   if (this%use_vector) then
-     call assertRelativelyEqual([611.7_r8], wv_sat_svp_ice(1, [h2otrip]), &
+     call assertRelativelyEqual([611.7_r8], shr_wv_sat_svp_ice(1, [h2otrip]), &
           tolerance=this%relative_tol)
   else
-     call assertRelativelyEqual(611.7_r8, wv_sat_svp_ice(h2otrip), &
+     call assertRelativelyEqual(611.7_r8, shr_wv_sat_svp_ice(h2otrip), &
           tolerance=this%relative_tol)
   end if
 
@@ -143,10 +143,10 @@ subroutine scheme_has_correct_liquid_trip_point(this)
   class(WVSchemeCase), intent(inout) :: this
 
   if (this%use_vector) then
-     call assertRelativelyEqual([611.7_r8], wv_sat_svp_liquid(1, [h2otrip]), &
+     call assertRelativelyEqual([611.7_r8], shr_wv_sat_svp_liquid(1, [h2otrip]), &
           tolerance=this%relative_tol)
   else
-     call assertRelativelyEqual(611.7_r8, wv_sat_svp_liquid(h2otrip), &
+     call assertRelativelyEqual(611.7_r8, shr_wv_sat_svp_liquid(h2otrip), &
           tolerance=this%relative_tol)
   end if
 
@@ -158,10 +158,10 @@ subroutine scheme_has_correct_liquid_value(this)
 
   ! Check a warm value (25 deg C).
   if (this%use_vector) then
-     call assertRelativelyEqual([3169._r8], wv_sat_svp_liquid(1, [tmelt+25._r8]), &
+     call assertRelativelyEqual([3169._r8], shr_wv_sat_svp_liquid(1, [tmelt+25._r8]), &
           tolerance=this%relative_tol)
   else
-     call assertRelativelyEqual(3169._r8, wv_sat_svp_liquid(tmelt+25._r8), &
+     call assertRelativelyEqual(3169._r8, shr_wv_sat_svp_liquid(tmelt+25._r8), &
           tolerance=this%relative_tol)
   end if
 
@@ -173,10 +173,10 @@ subroutine scheme_has_correct_ice_value(this)
 
   ! Check a cold value (-50 deg C).
   if (this%use_vector) then
-     call assertRelativelyEqual([3.935], wv_sat_svp_ice(1, [tmelt-50._r8]), &
+     call assertRelativelyEqual([3.935], shr_wv_sat_svp_ice(1, [tmelt-50._r8]), &
           tolerance=this%relative_tol)
   else
-     call assertRelativelyEqual(3.935, wv_sat_svp_ice(tmelt-50._r8), &
+     call assertRelativelyEqual(3.935, shr_wv_sat_svp_ice(tmelt-50._r8), &
           tolerance=this%relative_tol)
   end if
 
@@ -191,10 +191,10 @@ subroutine scheme_has_correct_mixed_trip_point(this)
   class(WVSchemeCase), intent(inout) :: this
 
   if (this%use_vector) then
-     call assertRelativelyEqual([611.7_r8], wv_sat_svp_mixed(1, [h2otrip]), &
+     call assertRelativelyEqual([611.7_r8], shr_wv_sat_svp_mixed(1, [h2otrip]), &
           tolerance=this%relative_tol)
   else
-     call assertRelativelyEqual(611.7_r8, wv_sat_svp_mixed(h2otrip), &
+     call assertRelativelyEqual(611.7_r8, shr_wv_sat_svp_mixed(h2otrip), &
           tolerance=this%relative_tol)
   end if
 
@@ -208,14 +208,14 @@ subroutine scheme_has_correct_mixed_as_ice(this)
 
   real(r8) :: ice_svp
 
-  ice_svp = wv_sat_svp_ice(t_all_ice)
+  ice_svp = shr_wv_sat_svp_ice(t_all_ice)
 
   ! Below the transition range, trans and ice should be equal.
   if (this%use_vector) then
-     call assertRelativelyEqual([ice_svp], wv_sat_svp_mixed(1, [t_all_ice]), &
+     call assertRelativelyEqual([ice_svp], shr_wv_sat_svp_mixed(1, [t_all_ice]), &
           tolerance=this%relative_tol)
   else
-     call assertRelativelyEqual(ice_svp, wv_sat_svp_mixed(t_all_ice), &
+     call assertRelativelyEqual(ice_svp, shr_wv_sat_svp_mixed(t_all_ice), &
           tolerance=this%relative_tol)
   end if
 
@@ -229,14 +229,14 @@ subroutine scheme_has_correct_mixed_as_liquid(this)
 
   real(r8) :: liquid_svp
 
-  liquid_svp = wv_sat_svp_liquid(t_all_liquid)
+  liquid_svp = shr_wv_sat_svp_liquid(t_all_liquid)
 
   ! Above the transition range, trans and water should be equal.
   if (this%use_vector) then
-     call assertRelativelyEqual([liquid_svp], wv_sat_svp_mixed(1, [t_all_liquid]), &
+     call assertRelativelyEqual([liquid_svp], shr_wv_sat_svp_mixed(1, [t_all_liquid]), &
           tolerance=this%relative_tol)
   else
-     call assertRelativelyEqual(liquid_svp, wv_sat_svp_mixed(t_all_liquid), &
+     call assertRelativelyEqual(liquid_svp, shr_wv_sat_svp_mixed(t_all_liquid), &
           tolerance=this%relative_tol)
   end if
 
@@ -251,17 +251,17 @@ subroutine scheme_has_correct_mixed_in_range(this)
 
   real(r8) :: ice_svp, liquid_svp
 
-  ice_svp = wv_sat_svp_ice(t_half)
-  liquid_svp = wv_sat_svp_liquid(t_half)
+  ice_svp = shr_wv_sat_svp_ice(t_half)
+  liquid_svp = shr_wv_sat_svp_liquid(t_half)
 
   ! Check that transition SVP is the average of the ice and water SVPs.
   if (this%use_vector) then
      call assertRelativelyEqual([0.5_r8 * (ice_svp+liquid_svp)], &
-          wv_sat_svp_mixed(1, [t_half]), &
+          shr_wv_sat_svp_mixed(1, [t_half]), &
           tolerance=this%relative_tol)
   else
      call assertRelativelyEqual(0.5_r8 * (ice_svp+liquid_svp), &
-          wv_sat_svp_mixed(t_half), &
+          shr_wv_sat_svp_mixed(t_half), &
           tolerance=this%relative_tol)
   end if
 

--- a/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat_each_method.pf
+++ b/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat_each_method.pf
@@ -72,15 +72,13 @@ subroutine setUp(this)
 
   class(WVSchemeCase), intent(inout) :: this
 
-  real(r8), parameter :: tboil = 373.16_r8
   real(r8), parameter :: epsilo = mwwv/mwdair
 
   character(len=128) :: errstring
 
   type(WVSatTableSpec) :: liquid_table_spec, ice_table_spec, mixed_table_spec
 
-  call wv_sat_init(tmelt, h2otrip, tboil, t_transition, epsilo, &
-       errstring)
+  call wv_sat_init(tmelt, h2otrip, t_transition, epsilo, errstring)
 
   if (errstring /= "") then
      call throw("Error from wv_sat_init: "//trim(errstring))

--- a/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat_each_method.pf
+++ b/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat_each_method.pf
@@ -111,9 +111,6 @@ end subroutine tearDown
 function getParameters() result(params)
   type(WVSchemeParameters), allocatable :: params(:)
 
-  ! The tolerance for Bolton is really high below because the ice scheme is
-  ! already really far off at -50 deg C. This should probably be addressed
-  ! somehow.
   params = [ &
        WVSchemeParameters("GoffGratch", 0.002_r8, .false., .false.), &
        WVSchemeParameters("MurphyKoop", 0.001_r8, .false., .false.), &

--- a/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat_each_method.pf
+++ b/share/csm_share/test/unit/shr_wv_sat_test/test_wv_sat_each_method.pf
@@ -1,0 +1,275 @@
+! This module has a parameterized test list for application to each of the
+! individual methods provided by shr_wv_sat_mod.
+module test_wv_sat_each_method
+
+use pfunit_mod
+
+use shr_kind_mod, only: r8 => shr_kind_r8
+use shr_const_mod, only: &
+     tmelt => shr_const_tkfrz, &
+     h2otrip => shr_const_tktrip, &
+     mwwv => shr_const_mwwv, &
+     mwdair => shr_const_mwdair
+use shr_wv_sat_mod
+
+implicit none
+public
+
+real(r8), parameter :: t_transition = 20._r8
+
+@TestParameter
+type, extends(AbstractTestParameter) :: WVSchemeParameters
+   character(len=32) :: scheme_name
+   real(r8) :: relative_tol
+   logical :: make_table
+   logical :: use_vector
+ contains
+   procedure :: toString
+end type WVSchemeParameters
+
+@TestCase(testParameters={getParameters()}, constructor=new_WVSchemeCase)
+type, extends(ParameterizedTestCase) :: WVSchemeCase
+   character(len=32) :: scheme_name
+   real(r8) :: relative_tol
+   logical :: make_table
+   logical :: use_vector
+ contains
+   procedure :: setUp
+   procedure :: tearDown
+end type WVSchemeCase
+
+contains
+
+! Simple routines to convert parameters to a test case or a string,
+! respectively.
+
+function new_WVSchemeCase(params) result(test)
+  type(WVSchemeParameters), intent(in) :: params
+  type(WVSchemeCase) :: test
+
+  test%scheme_name = params%scheme_name
+  test%relative_tol = params%relative_tol
+  test%make_table = params%make_table
+  test%use_vector = params%use_vector
+
+end function new_WVSchemeCase
+
+function toString(this) result(string)
+  class(WVSchemeParameters), intent(in) :: this
+  character(:), allocatable :: string
+
+  character(len=80) :: buffer
+
+  write(buffer,*) "(scheme=",this%scheme_name,",table=",this%make_table, &
+       ",vec=",this%use_vector,")"
+
+  string = trim(buffer)
+
+end function toString
+
+! setUp/tearDown to init the module and to actually set the current scheme.
+subroutine setUp(this)
+
+  class(WVSchemeCase), intent(inout) :: this
+
+  real(r8), parameter :: tboil = 373.16_r8
+  real(r8), parameter :: epsilo = mwwv/mwdair
+
+  character(len=128) :: errstring
+
+  type(WVSatTableSpec) :: liquid_table_spec, ice_table_spec, mixed_table_spec
+
+  call wv_sat_init(tmelt, h2otrip, tboil, t_transition, epsilo, &
+       errstring)
+
+  if (errstring /= "") then
+     call throw("Error from wv_sat_init: "//trim(errstring))
+  end if
+
+  @assertTrue(wv_sat_set_default(this%scheme_name))
+
+  if (this%make_table) then
+     liquid_table_spec = WVSatTableSpec(151, tmelt-50._r8, 1._r8)
+     ice_table_spec = WVSatTableSpec(106, tmelt-100._r8, 1._r8)
+     mixed_table_spec = WVSatTableSpec(201, tmelt-100._r8, 1._r8)
+     call wv_sat_make_tables(&
+          liquid_spec_in=liquid_table_spec, &
+          ice_spec_in=ice_table_spec, &
+          mixed_spec_in=mixed_table_spec)
+  end if
+
+end subroutine setUp
+
+subroutine tearDown(this)
+
+  class(WVSchemeCase), intent(inout) :: this
+
+  call wv_sat_final()
+
+end subroutine tearDown
+
+! List of testable schemes.
+
+function getParameters() result(params)
+  type(WVSchemeParameters), allocatable :: params(:)
+
+  ! The tolerance for Bolton is really high below because the ice scheme is
+  ! already really far off at -50 deg C. This should probably be addressed
+  ! somehow.
+  params = [ &
+       WVSchemeParameters("GoffGratch", 0.002_r8, .false., .false.), &
+       WVSchemeParameters("MurphyKoop", 0.001_r8, .false., .false.), &
+       WVSchemeParameters("Flatau", 0.003_r8, .false., .false.), &
+       WVSchemeParameters("Bolton", 0.001_r8, .false., .false.), &
+       WVSchemeParameters("GoffGratch", 0.002_r8, .true., .false.), &
+       WVSchemeParameters("GoffGratch", 0.002_r8, .false., .true.), &
+       WVSchemeParameters("GoffGratch", 0.002_r8, .true., .true.) ]
+
+end function getParameters
+
+! Tests for water and ice functions for each scheme.
+
+@Test
+subroutine scheme_has_correct_ice_trip_point(this)
+  class(WVSchemeCase), intent(inout) :: this
+
+  if (this%use_vector) then
+     call assertRelativelyEqual([611.7_r8], wv_sat_svp_ice(1, [h2otrip]), &
+          tolerance=this%relative_tol)
+  else
+     call assertRelativelyEqual(611.7_r8, wv_sat_svp_ice(h2otrip), &
+          tolerance=this%relative_tol)
+  end if
+
+end subroutine scheme_has_correct_ice_trip_point
+
+@Test
+subroutine scheme_has_correct_liquid_trip_point(this)
+  class(WVSchemeCase), intent(inout) :: this
+
+  if (this%use_vector) then
+     call assertRelativelyEqual([611.7_r8], wv_sat_svp_liquid(1, [h2otrip]), &
+          tolerance=this%relative_tol)
+  else
+     call assertRelativelyEqual(611.7_r8, wv_sat_svp_liquid(h2otrip), &
+          tolerance=this%relative_tol)
+  end if
+
+end subroutine scheme_has_correct_liquid_trip_point
+
+@Test
+subroutine scheme_has_correct_liquid_value(this)
+  class(WVSchemeCase), intent(inout) :: this
+
+  ! Check a warm value (25 deg C).
+  if (this%use_vector) then
+     call assertRelativelyEqual([3169._r8], wv_sat_svp_liquid(1, [tmelt+25._r8]), &
+          tolerance=this%relative_tol)
+  else
+     call assertRelativelyEqual(3169._r8, wv_sat_svp_liquid(tmelt+25._r8), &
+          tolerance=this%relative_tol)
+  end if
+
+end subroutine scheme_has_correct_liquid_value
+
+@Test
+subroutine scheme_has_correct_ice_value(this)
+  class(WVSchemeCase), intent(inout) :: this
+
+  ! Check a cold value (-50 deg C).
+  if (this%use_vector) then
+     call assertRelativelyEqual([3.935], wv_sat_svp_ice(1, [tmelt-50._r8]), &
+          tolerance=this%relative_tol)
+  else
+     call assertRelativelyEqual(3.935, wv_sat_svp_ice(tmelt-50._r8), &
+          tolerance=this%relative_tol)
+  end if
+
+end subroutine scheme_has_correct_ice_value
+
+! Tests for the combined water-ice function with transition range.
+! Technically, these don't have to be done for each scheme, but it doesn't hurt
+! to run them many times, since the tests are very quick.
+
+@Test
+subroutine scheme_has_correct_mixed_trip_point(this)
+  class(WVSchemeCase), intent(inout) :: this
+
+  if (this%use_vector) then
+     call assertRelativelyEqual([611.7_r8], wv_sat_svp_mixed(1, [h2otrip]), &
+          tolerance=this%relative_tol)
+  else
+     call assertRelativelyEqual(611.7_r8, wv_sat_svp_mixed(h2otrip), &
+          tolerance=this%relative_tol)
+  end if
+
+end subroutine scheme_has_correct_mixed_trip_point
+
+@Test
+subroutine scheme_has_correct_mixed_as_ice(this)
+  class(WVSchemeCase), intent(inout) :: this
+
+  real(r8) :: t_all_ice = tmelt - t_transition - 1._r8
+
+  real(r8) :: ice_svp
+
+  ice_svp = wv_sat_svp_ice(t_all_ice)
+
+  ! Below the transition range, trans and ice should be equal.
+  if (this%use_vector) then
+     call assertRelativelyEqual([ice_svp], wv_sat_svp_mixed(1, [t_all_ice]), &
+          tolerance=this%relative_tol)
+  else
+     call assertRelativelyEqual(ice_svp, wv_sat_svp_mixed(t_all_ice), &
+          tolerance=this%relative_tol)
+  end if
+
+end subroutine scheme_has_correct_mixed_as_ice
+
+@Test
+subroutine scheme_has_correct_mixed_as_liquid(this)
+  class(WVSchemeCase), intent(inout) :: this
+
+  real(r8) :: t_all_liquid = tmelt + 1._r8
+
+  real(r8) :: liquid_svp
+
+  liquid_svp = wv_sat_svp_liquid(t_all_liquid)
+
+  ! Above the transition range, trans and water should be equal.
+  if (this%use_vector) then
+     call assertRelativelyEqual([liquid_svp], wv_sat_svp_mixed(1, [t_all_liquid]), &
+          tolerance=this%relative_tol)
+  else
+     call assertRelativelyEqual(liquid_svp, wv_sat_svp_mixed(t_all_liquid), &
+          tolerance=this%relative_tol)
+  end if
+
+end subroutine scheme_has_correct_mixed_as_liquid
+
+@Test
+subroutine scheme_has_correct_mixed_in_range(this)
+  class(WVSchemeCase), intent(inout) :: this
+
+  ! Temperature at which we are halfway through the transition range.
+  real(r8), parameter :: t_half = tmelt - 0.5*t_transition
+
+  real(r8) :: ice_svp, liquid_svp
+
+  ice_svp = wv_sat_svp_ice(t_half)
+  liquid_svp = wv_sat_svp_liquid(t_half)
+
+  ! Check that transition SVP is the average of the ice and water SVPs.
+  if (this%use_vector) then
+     call assertRelativelyEqual([0.5_r8 * (ice_svp+liquid_svp)], &
+          wv_sat_svp_mixed(1, [t_half]), &
+          tolerance=this%relative_tol)
+  else
+     call assertRelativelyEqual(0.5_r8 * (ice_svp+liquid_svp), &
+          wv_sat_svp_mixed(t_half), &
+          tolerance=this%relative_tol)
+  end if
+
+end subroutine scheme_has_correct_mixed_in_range
+
+end module test_wv_sat_each_method


### PR DESCRIPTION
This PR has two related goals:
1. Create a module with a superset of the the functionality in CAM's `wv_sat_methods` and CLUBB's `saturation`, combined with a more flexible set of lookup tables, and move it into CIME. This module is called `shr_wv_sat_mod`. For comparison, you can see `src/physics/cam/wv_sat_methods.F90` and `src/physics/clubb/saturation.F90` in CAM, but the differences are large enough that a diff may not be that helpful.
2. Add changes suggested by Chris Kerr for optimization of the MG2 microphysics, especially by speeding up transcendental functions when using Intel 15. Chris made some significant changes to `wv_sat_methods` in the process, which have been translated to `shr_wv_sat_mod` here. (This was not exactly trivial, but by following some of Chris's suggestions I was able to check that vector functions in the new module still vectorize, and are sped up significantly, as long as the options added in `Depends.intel` are used.)

Note that the `seq_infodata_inparm` now controls `shr_wv_sat_mod`, rather than a CAM namelist controlling it. This is unfortunate for a minority of CAM users who are used to the existing CAM namelist options, but this change seems unavoidable with `shr_wv_sat_mod` being outside of CAM. (See the commit messages for a bit more on why I moved this in the first place.)

For the moment, I have left lookup tables off by default in the saturation code, using the `wv_sat_use_tables` namelist option. The general feeling in AMP and ACOM is that these lookup tables may be acceptable, but not desirable, given that lookup tables have frequently caused large numerical errors or crashes in CAM and especially WACCM. However, lookup tables seem to significantly speed up the run in CAM4/CAM5, as well as the current versions of both CLUBB and UNICON.

Most likely we will want to turn the tables on by default for CAM4/CAM5/CAM5.4 compsets (unless these compsets are removed entirely before CESM 2). We can avoid using them for CAM5.5 and higher if enough of the code is vectorized that performance becomes competitive with lookup tables on our supported machines.
