### PR TITLE
Change ocn(1) to ice(1) in call to seq_map_init_rcfile for Rg2i.

### DIFF
--- a/driver_cpl/driver/prep_ice_mod.F90
+++ b/driver_cpl/driver/prep_ice_mod.F90
@@ -160,7 +160,7 @@ contains
              write(logunit,*) ' '
              write(logunit,F00) 'Initializing mapper_Rg2i'
           end if
-          call seq_map_init_rcfile(mapper_Rg2i, glc(1), ocn(1), &
+          call seq_map_init_rcfile(mapper_Rg2i, glc(1), ice(1), &
                'seq_maps.rc','glc2ice_rmapname:','glc2ice_rmaptype:',samegrid_ig, &
                'mapper_Rg2i initialization', esmf_map_flag)
        endif


### PR DESCRIPTION
Jeremy Fyke noticed this bug. It shouldn't have any effect, since the ocn and
ice resolutions are always the same. But this seems worth fixing anyway.

I have not run any testing on this change. Once someone signs off on it, I'll run the cime tests then bring it to master.
