### PR TITLE
$CASE.run was over-writing CaseStatus

### DIFF
--- a/machines/template.cesmrun
+++ b/machines/template.cesmrun
@@ -168,7 +168,7 @@ sub doPreRunChecks()
 	$ENV{'LID'} = $LID;
 	$ENV{'sdate'} = $sdate;
 	
-	open my $CS, ">", "./CaseStatus" or die "Could not open CaseStatus file for writing!";
+	open my $CS, ">>", "./CaseStatus" or die "Could not open CaseStatus file for writing!";
 	print $CS "run started $sdate\n";
 	close $CS;
 	


### PR DESCRIPTION
This update is a one-character fix to have $CASE.run append output to
CaseStatus

Note: this is a fix for issue #41 
