### PR TITLE
FIX: Must check for 'cimeroot' option in all use cases

### DIFF
--- a/machines/configure
+++ b/machines/configure
@@ -163,14 +163,14 @@ if (!$opts{'list'}) {
     if($opts{'output_format'}){
 	$output_format = $opts{'output_format'};
     }
-    if($opts{'cimeroot'}){
-	$cimeroot = $opts{'cimeroot'};
-    }
     if($opts{'mach_dir'}){
 	$machdir = $opts{'mach_dir'};
     }
 }
 
+if($opts{'cimeroot'}){
+$cimeroot = $opts{'cimeroot'};
+}
 $cimeroot = absolute_path($ENV{CIMEROOT}) unless defined($cimeroot);
 (-d "$cimeroot")  or  die <<"EOF";
 ** Cannot find cimeroot directory \"$cimeroot\"  


### PR DESCRIPTION
The 'cimeroot' option must be defined for all use cases, including the
case when listing all available machines.  Prior to this commit, the
'cimeroot' option was never parsed if the '-list' option was given.
However, the script errors out if the 'cimeroot' is not defined, even
when listing.
