### PR TITLE
Fix finding component history file for baseline gen / comp, and other minor changes

### DIFF
--- a/scripts/Tools/baseline_gen_comp
+++ b/scripts/Tools/baseline_gen_comp
@@ -252,12 +252,12 @@ for testcase in $tests; do
 
     if [ -n "$compare_tag" ]; then
 	echo "--- Baseline Comparison ---: "
-	${tools_dir}/component_compgen_baseline.sh -baseline_dir ${baselineroot}/${compare_tag}/${testcase_base} -test_dir ${rundir} -testcase_base ${testcase_base} -compare_tag ${compare_tag} -cprnc_exe ${cprnc_path}
+	${tools_dir}/component_compgen_baseline.sh -baseline_dir ${baselineroot}/${compare_tag}/${testcase_base} -test_dir ${rundir} -testcase ${testcase} -testcase_base ${testcase_base} -compare_tag ${compare_tag} -cprnc_exe ${cprnc_path}
     fi
 
     if [ -n "$generate_tag" ]; then
 	echo "--- Baseline Generation ---: "
-	${tools_dir}/component_compgen_baseline.sh -baseline_dir ${baselineroot}/${generate_tag}/${testcase_base} -test_dir ${rundir} -testcase_base ${testcase_base} -generate_tag ${generate_tag} -cprnc_exe ${cprnc_path}
+	${tools_dir}/component_compgen_baseline.sh -baseline_dir ${baselineroot}/${generate_tag}/${testcase_base} -test_dir ${rundir} -testcase ${testcase} -testcase_base ${testcase_base} -generate_tag ${generate_tag} -cprnc_exe ${cprnc_path}
     fi
 
     echo ""

--- a/scripts/Tools/cesm_build.csh
+++ b/scripts/Tools/cesm_build.csh
@@ -15,7 +15,7 @@ echo " .... building model executable (calling ./Buildconf/cesm_build.pl) "
 
 ./Buildconf/cesm_build.pl $CASEROOT || exit -1
 
-echo " .... successfully build model executable"
+echo " .... successfully built model executable"
 
 exit 0;
 

--- a/scripts/Tools/component_compare_test.sh
+++ b/scripts/Tools/component_compare_test.sh
@@ -231,7 +231,7 @@ for model in ${models[*]}; do
 	    hist2_0001=`cd $rundir; ls -1 ${testcase}.${model}_0001.${extension}.*.nc.${suffix2} 2>/dev/null | tail -1`
 	    hist2_0002=`cd $rundir; ls -1 ${testcase}.${model}_0002.${extension}.*.nc.${suffix2} 2>/dev/null | tail -1`
 
-	    if  [[ -f ${hist1} ]] && [[ -f ${hist2_0001} ]] && [[ -f ${hist2_0001} ]] ; then
+	    if  [[ -f ${hist1} ]] && [[ -f ${hist2_0001} ]] && [[ -f ${hist2_0002} ]] ; then
 
 		if [ "$model" != "cpl" ]; then
 		    # do all model comparisons except for cpl, since cpl history does not write out all instances - but just instance 1
@@ -262,7 +262,7 @@ for model in ${models[*]}; do
 	    hist1_0002=`cd $rundir; ls -1 ${testcase}.${model}_0002.${extension}.*.nc.${suffix1} 2>/dev/null | tail -1`
 	    hist2_0002=`cd $rundir; ls -1 ${testcase}.${model}_0002.${extension}.*.nc.${suffix2} 2>/dev/null | tail -1`
 
-	    if  [[ -f ${hist1_0001} ]] && [[ -f ${hist1_0002} ]] && [[ -f ${hist2_0001} ]] && [[ -f ${hist2_0001} ]] ; then
+	    if  [[ -f ${hist1_0001} ]] && [[ -f ${hist1_0002} ]] && [[ -f ${hist2_0001} ]] && [[ -f ${hist2_0002} ]] ; then
 
 		compare_result=`${tools_dir}/component_compare.sh -baseline_dir "$rundir" -test_dir "$rundir" -baseline_hist "$hist1_0001" -test_hist "$hist1_0002" -cprnc_exe "$cprnc_exe"`
 		compare_status=`get_status "$compare_result"`

--- a/scripts/Tools/component_compgen_baseline.sh
+++ b/scripts/Tools/component_compgen_baseline.sh
@@ -29,7 +29,9 @@ function Usage {
     echo ""
     echo "     -test_dir <path>      Path to the given test's run directory (required)"
     echo ""
-    echo "     -testcase_base <name> Name of test case, used for printing results (required)"
+    echo "     -testcase <name>      Full name of case including testid (required)"
+    echo ""
+    echo "     -testcase_base <name> Name of test case without testid, used for printing results (required)"
     echo ""
     echo "     -generate_tag <tag>   Tag to use for baseline generation (optional)"
     echo ""
@@ -96,6 +98,7 @@ function print_status {
 # Begin main script
 #======================================================================
 
+progname=`basename $0`
 tools_dir=`dirname $0`
 
 #----------------------------------------------------------------------
@@ -123,6 +126,10 @@ while [ $# -gt 0 ]; do
 	    ;;
 	-test_dir )
 	    test_dir=$2
+	    shift
+	    ;;
+	-testcase )
+	    testcase=$2
 	    shift
 	    ;;
 	-testcase_base )
@@ -165,6 +172,10 @@ if [ -z "$baseline_dir" ]; then
 fi
 if [ -z "$test_dir" ]; then
     echo "$progname: test_dir must be provided" >&2
+    error=1
+fi
+if [ -z "$testcase" ]; then
+    echo "$progname: testcase must be provided" >&2
     error=1
 fi
 if [ -z "$testcase_base" ]; then
@@ -242,7 +253,7 @@ for model in ${models[*]}; do
         # Note that we need a * after ${model} to capture multi-instance
         # output
 
-	test_hist=`cd $test_dir; ls -1 *.${model}*.${extension}.*.nc.base 2>/dev/null | tail -1`
+	test_hist=`cd $test_dir; ls -1 ${testcase}.${model}*.${extension}.*.nc.base 2>/dev/null | tail -1`
 
 	if [ -n "$test_hist" ]; then
 

--- a/scripts/Tools/testcase_setup
+++ b/scripts/Tools/testcase_setup
@@ -367,7 +367,7 @@ my $testcase_end = <<'END_TEST';
 
        if ("$continue_compare" == 'yes') then
           # compare component history fiels with baseline
-          ${SCRIPTSROOT}/Tools/component_compgen_baseline.sh -baseline_dir $BASECMP_DIR -test_dir $RUNDIR -compare_tag $BASECMP_NAME -testcase_base $CASEBASEID -msg "baseline: compare .base file with $BASECMP_NAME file">>& $TESTSTATUS_OUT
+          ${SCRIPTSROOT}/Tools/component_compgen_baseline.sh -baseline_dir $BASECMP_DIR -test_dir $RUNDIR -compare_tag $BASECMP_NAME -testcase $CASE -testcase_base $CASEBASEID -msg "baseline: compare .base file with $BASECMP_NAME file">>& $TESTSTATUS_OUT
 
 	  if (-e $BASECMP_DIR/${TESTSTATUS_LOG:t}) then
 	     set bbb1 = `grep perf $BASECMP_DIR/${TESTSTATUS_LOG:t} | grep CHECK | grep -v baseline`
@@ -440,7 +440,7 @@ my $testcase_end = <<'END_TEST';
        endif
 
        if ("$continue_generate" == 'yes') then
-          ${SCRIPTSROOT}/Tools/component_compgen_baseline.sh -baseline_dir $BASEGEN_DIR -test_dir $RUNDIR -generate_tag $BASEGEN_NAME -testcase_base $CASEBASEID >>& $TESTSTATUS_OUT
+          ${SCRIPTSROOT}/Tools/component_compgen_baseline.sh -baseline_dir $BASEGEN_DIR -test_dir $RUNDIR -generate_tag $BASEGEN_NAME -testcase $CASE -testcase_base $CASEBASEID >>& $TESTSTATUS_OUT
 
 	  # save last coupler log file to baseline directory
 	  cp $CplLogFile $BASEGEN_DIR/cpl.log || echo "WARNING: could not copy $CplLogFile to $BASEGEN_DIR " >>& $TESTSTATUS_LOG


### PR DESCRIPTION
Main diff is in component_compgen_baseline.sh:
-       test_hist=`cd $test_dir; ls -1
      *.${model}*.${extension}.*.nc.base 2>/dev/null | tail -1`
-       test_hist=`cd $test_dir; ls -1
      ${testcase}.${model}*.${extension}.*.nc.base 2>/dev/null | tail -1`

The original version was too greedy. This meant, for example, that in
a test that had 'cam' in its name (e.g., because of a cam testmods
directory), it would sometimes find a clm history file when it was
looking for a cam history file, because the clm history file name
matched the original version.

Changing this required passing the full testcase (i.e., CASE) into
component_compgen_baseline.sh.

Also, unrelated minor changes:

(1) Fix file tests for multi-instance: There were typos in the file tests for the existence of history files for multi-instance cases: checking for hist2_0001 twice rather than hist2_0001 and hist2_0002.

(2) Fix grammatical error in output of build script

Test suite: drv prealpha yellowstone
Test baseline: cesm1_4_alpha06c
Test namelist changes: none
Test status: bit for bit
However, there will be apparent differences in some component baseline comparisons, because (for example) CAM history files will be compared against CLM history files (which were previously copied to cam.h0.nc).

Also tested a case that was previously giving problems (ERP_Ln9.f19_f19.FC5L45BGC.yellowstone_intel.cam-outfrq9s) and confirmed that the correct history files were used for generation / comparison for each component.

Code reviews: none yet
