### PR TITLE
Fix unit test build to work with mpi-based pFUnit on yellowstone.

### DIFF
--- a/README.unit_testing
+++ b/README.unit_testing
@@ -1,2 +1,6 @@
-# To run all CIME unit tests on yellowstone, run the following command:
-tools/unit_testing/run_tests.py --test-spec-dir=. --compiler=intel
+# To run all CIME unit tests on caldera, run the following command:
+# (Note that this must be done from an interactive caldera session, not from yellowstone)
+tools/unit_testing/run_tests.py --test-spec-dir=. --compiler=intel --mpilib=mpich2 --mpirun-command=mpirun.lsf --cmake-args=-DPAPI_LIB=/glade/apps/opt/papi/5.3.0/intel/12.1.5/lib64
+
+# The inclusion of PAPI_LIB is needed above since config_compilers includes:
+#   <ADD_SLIBS> -Wl,-rpath ${PAPI_LIB} -L${PAPI_LIB} -lpapi</ADD_SLIBS>

--- a/externals/CMake/pFUnit_utils.cmake
+++ b/externals/CMake/pFUnit_utils.cmake
@@ -50,8 +50,14 @@
 #    COMMAND - Command to run the pFUnit test
 #       - Defaults to executable_name
 #       - Needs to be given if you need more on the command line than just the executable
-#         name, such as an aprun command, or setting the number of threads
+#         name, such as setting the number of threads
 #       - A multi-part command should NOT be enclosed in quotes (see example below)
+#       - COMMAND should NOT contain the mpirun command: this is specified
+#         separately, via the PFUNIT_MPIRUN CMake variable
+#
+# Non-standard CMake variables used:
+#    PFUNIT_MPIRUN - If executables need to be prefixed with an mpirun command,
+#      PFUNIT_MPIRUN gives this prefix (e.g., "mpirun")
 #
 # Does everything needed to create a pFUnit-based test, wrapping
 # add_pFUnit_executable, add_test, and define_pFUnit_failure. 
@@ -182,6 +188,9 @@ endfunction(define_pFUnit_failure)
 #
 # Optional input variables are GEN_OUTPUT_DIRECTORY and COMMAND (see usage notes at the
 # top of this file for details).
+#
+# If executables need to be prefixed with an mpirun command, this prefix (e.g.,
+# "mpirun") should be given in the CMAKE variable PFUNIT_MPIRUN.
 function(create_pFUnit_test test_name executable_name pf_file_list fortran_source_list)
 
   # Parse optional arguments
@@ -202,6 +211,9 @@ function(create_pFUnit_test test_name executable_name pf_file_list fortran_sourc
   if (NOT MY_COMMAND)
     set(MY_COMMAND ${executable_name})
   endif()
+
+  # Prefix command with an mpirun command
+  set (MY_COMMAND ${PFUNIT_MPIRUN} ${MY_COMMAND})
 
   # Do the work
   add_pFUnit_executable(${executable_name} "${pf_file_list}"

--- a/machines/config_compilers.xml
+++ b/machines/config_compilers.xml
@@ -500,13 +500,13 @@ for mct, etc.
   <TRILINOS_PATH>$(TRILINOS_PATH)</TRILINOS_PATH>
   <PAPI_INC> /glade/apps/opt/papi/5.3.0/intel/12.1.5/include/</PAPI_INC>
   <PAPI_LIB>/glade/apps/opt/papi/5.3.0/intel/12.1.5/lib64 </PAPI_LIB>
-  <ADD_SLIBS> -Wl,-rpath $(PAPI_LIB) -L$(PAPI_LIB) -lpapi</ADD_SLIBS>
+  <ADD_SLIBS> -Wl,-rpath ${PAPI_LIB} -L${PAPI_LIB} -lpapi</ADD_SLIBS>
 </compiler>
 
 
 
 <compiler MACH="yellowstone" COMPILER="intel">
-  <PFUNIT_PATH>/glade/u/home/sacks/pFUnit/pFUnit3.0.1_Intel14.0.2_Serial</PFUNIT_PATH>
+  <PFUNIT_PATH>/glade/u/home/sacks/pFUnit/pFUnit3.1_Intel15.0.1_MPI</PFUNIT_PATH>
 </compiler>
 
 <compiler MACH="yellowstone" COMPILER="pgi">

--- a/share/csm_share/test/unit/shr_assert_test/CMakeLists.txt
+++ b/share/csm_share/test/unit/shr_assert_test/CMakeLists.txt
@@ -7,11 +7,7 @@ set(sources_needed shr_kind_mod.F90 shr_infnan_mod.F90
 
 extract_sources("${sources_needed}" "${share_sources}" test_sources)
 
-add_pFUnit_executable(assert_test_exe "${pf_sources}"
-  ${CMAKE_CURRENT_BINARY_DIR} "${test_sources}")
+create_pFUnit_test(assert assert_test_exe "${pf_sources}" "${test_sources}")
 
 declare_generated_dependencies(assert_test_exe "${share_genf90_sources}")
 
-add_test(assert assert_test_exe)
-
-define_pFUnit_failure(assert)

--- a/share/csm_share/test/unit/shr_spfn_test/CMakeLists.txt
+++ b/share/csm_share/test/unit/shr_spfn_test/CMakeLists.txt
@@ -7,11 +7,6 @@ set(sources_needed shr_kind_mod.F90 shr_const_mod.F90 shr_infnan_mod.F90
 
 extract_sources("${sources_needed}" "${share_sources}" test_sources)
 
-add_pFUnit_executable(spfn_test_exe "${pf_sources}"
-  ${CMAKE_CURRENT_BINARY_DIR} "${test_sources}")
+create_pFUnit_test(spfn spfn_test_exe "${pf_sources}" "${test_sources}")
 
 declare_generated_dependencies(spfn_test_exe "${share_genf90_sources}")
-
-add_test(spfn spfn_test_exe)
-
-define_pFUnit_failure(spfn)

--- a/tools/unit_testing/python/machine_setup.py
+++ b/tools/unit_testing/python/machine_setup.py
@@ -37,8 +37,11 @@ def get_machine_name():
         name = "mira"
     elif re.match("^cetuslac[0-9]+", name):
         name = "mira"
-    elif re.match("^caldera.*", name):
-        name = "caldera"
+    elif re.match("^caldera.*", name) or re.match("^pronghorn.*", name):
+        # Use yellowstone settings for caldera/pronghorn, since the mahcines
+        # files aren't set up explicitly for those machines, and they have the
+        # same configuration as yellowstone.
+        name = "yellowstone"
     return name
 
 def load_machine_env(compiler):
@@ -56,7 +59,7 @@ def load_machine_env(compiler):
         mod.load("ncarenv/1.0")
         mod.load("ncarbinlibs/1.0")
         if compiler == "intel":
-            mod.load("intel/15.0.0")
+            mod.load("intel/15.0.1")
             mod.load("mkl/11.1.2")
         elif compiler == "pgi":
             mod.load("pgi/13.9")

--- a/tools/unit_testing/run_tests.py
+++ b/tools/unit_testing/run_tests.py
@@ -99,6 +99,10 @@ parser.add_option(
 runs "make clean"."""
     )
 parser.add_option(
+    "--cmake-args", dest="cmake_args",
+    help="""Additional arguments to pass to CMake."""
+    )
+parser.add_option(
     "--color", dest="color", action="store_true",
     default=sys.stdout.isatty(),
     help="""Turn on colorized output."""
@@ -128,6 +132,20 @@ parser.add_option(
 
 In a CESM checkout this option is unnecessary, because this script can
 autodetect this location."""
+    )
+parser.add_option(
+    "--mpilib", dest="mpilib",
+    help="""MPI Library to use in build.
+
+Required argument (until we can get this from config_machines)
+Must match an MPILIB option in config_compilers.xml.
+e.g., for yellowstone, can use 'mpich2'."""
+    )
+parser.add_option(
+    "--mpirun-command", dest="mpirun_command", default="",
+    help="""Command to use to run an MPI executable.
+
+If not specified, does not use any mpirun prefix to run executables."""
     )
 parser.add_option(
     "--test-spec-dir", dest="test_spec_dir",
@@ -175,6 +193,13 @@ if options.test_spec_dir is None and options.xml_test_list is None:
     parser.print_help()
     output.print_error(
         "You must specify either --test-spec-dir or --xml-test-list."
+        )
+    raise Exception("Missing required argument.")
+
+if options.mpilib is None:
+    parser.print_help()
+    output.print_error(
+        "You must specify --mpilib."
         )
     raise Exception("Missing required argument.")
 
@@ -278,6 +303,7 @@ if machines_dir is not None:
 
     mach_settings = MachineCompilerSettings(options.compiler.lower(),
                                             compiler_xml,
+                                            mpilib=options.mpilib,
                                             use_env_compiler=options.use_env_compiler,
                                             use_openmp=options.use_openmp)
     mach_settings.set_compiler_env()
@@ -312,6 +338,7 @@ def cmake_stage(name, test_spec_dir):
             test_spec_dir,
             "-DCESM_CMAKE_MODULE_DIRECTORY="+cesm_cmake_dir,
             "-DCMAKE_BUILD_TYPE="+options.build_type,
+            "-DPFUNIT_MPIRUN="+options.mpirun_command,
             ]
 
         if options.verbose:
@@ -328,6 +355,9 @@ def cmake_stage(name, test_spec_dir):
         if not options.color:
             cmake_command.append("-DUSE_COLOR=OFF")
 
+        if options.cmake_args is not None:
+            cmake_command.extend(options.cmake_args.split(" "))
+            
         macros_path = os.path.abspath("CESM_Macros.cmake")
 
         if machines_dir is not None:


### PR DESCRIPTION
This required adding a number of new options to run_tests.py to set some
machine-specific stuff. This also required ensuring that all tests use
create_pFUnit_test, which now adds an mpirun prefix to the command used to run
tests.

Note that the new option that allows setting PAPI_LIB via cmake-args was not
directly related to switching to mpi-based pFUnit, but rather was needed because
-lpapi has been added to the link line for yellowstone-intel.

Test suite: yellowstone-intel drv prealpha
   Note that the only changes that affect system runs were in config_compilers.xml, in the yellowstone-intel section
Test baseline: cesm1_4_alpha06c
Test namelist changes: none
Test status: bit for bit
   Note this expected CFAIL, which should be fixed soon: CFAIL CME_Ld3.f45_g37_rx1.A.yellowstone_intel

Also, ran cime unit tests on yellowstone and on my Mac laptop.

Code reviews: none yet
