### PR TITLE
Cleanbuild

### DIFF
--- a/machines/Makefile
+++ b/machines/Makefile
@@ -748,7 +748,7 @@ cleanwav:
 
 cleanglc: 
 	$(RM) -f $(LIBROOT)/libglc.a
-	cd $(EXEROOT)/glc/obj ; $(RM) -f *.o *.mod
+	$(RM) -fr $(EXEROOT)/glc 
 
 cleanice: 
 	$(RM) -f $(LIBROOT)/libice.a

--- a/scripts/Tools/cesm_clean_build
+++ b/scripts/Tools/cesm_clean_build
@@ -91,3 +91,8 @@ foreach my $lib (@opts){
     }
 }
 system($sysmod) == 0 or die "$sysmod failed: $?\n";
+my @lockedfiles = glob("LockedFiles/env_build*");
+foreach my $lf (@lockedfiles) {
+    unlink($lf);
+}
+system("./xmlchange SMP_BUILD=0 NINST_BUILD=0 BUILD_COMPLETE=FALSE BUILD_STATUS=0");

--- a/scripts/Tools/cesm_clean_build
+++ b/scripts/Tools/cesm_clean_build
@@ -95,4 +95,4 @@ my @lockedfiles = glob("LockedFiles/env_build*");
 foreach my $lf (@lockedfiles) {
     unlink($lf);
 }
-system("./xmlchange SMP_BUILD=0 NINST_BUILD=0 BUILD_COMPLETE=FALSE BUILD_STATUS=0");
+system("./xmlchange SMP_BUILD=0,NINST_BUILD=0,BUILD_COMPLETE=FALSE,BUILD_STATUS=0");


### PR DESCRIPTION
Fixes issues with CME test and new cesm_clean_build script.

DONE ERS_D_Ld3.f45_g37_rx1.A.yellowstone_intel : (test finished, successful coupler log) 
--- Test Functionality ---:
PASS ERS_D_Ld3.f45_g37_rx1.A.yellowstone_intel.cpl.hi.nc : test compare cpl.hi (.base and .rest files) 
PASS ERS_D_Ld3.f45_g37_rx1.A.yellowstone_intel : test functionality summary (ERS_test) 
PASS ERS_D_Ld3.f45_g37_rx1.A.yellowstone_intel.memleak
--- Test time is 148 seconds ---

DONE PEM.f19_g16_rx1.A.yellowstone_intel : (test finished, successful coupler log) 
--- Test Functionality ---:
PASS PEM.f19_g16_rx1.A.yellowstone_intel.cpl.hi.nc : test compare cpl.hi (.base and .modpes files) 
PASS PEM.f19_g16_rx1.A.yellowstone_intel : test functionality summary (PEM_test) 
--- Test time is 101 seconds ---

DONE ERS_Lm3.T62_g16.AIAF.yellowstone_intel : (test finished, successful coupler log) 
--- Test Functionality ---:
PASS ERS_Lm3.T62_g16.AIAF.yellowstone_intel.cpl.hi.nc : test compare cpl.hi (.base and .rest files) 
PASS ERS_Lm3.T62_g16.AIAF.yellowstone_intel : test functionality summary (ERS_test) 
PASS ERS_Lm3.T62_g16.AIAF.yellowstone_intel.memleak
--- Test time is 234 seconds ---

DONE CME_Ld3.f45_g37_rx1.A.yellowstone_intel : (test finished, successful coupler log) 
--- Test Functionality: ---
PASS CME_Ld3.f45_g37_rx1.A.yellowstone_intel.cpl.hi.nc : test compare cpl.hi (.base and .esmf files) 
PASS CME_Ld3.f45_g37_rx1.A.yellowstone_intel : test functionality summary (esmf test .base and .esmf files) 
--- Test time is 72 seconds ---

DONE ERS_D_Ld3.f19_g16.X.yellowstone_intel : (test finished, successful coupler log) 
--- Test Functionality ---:
PASS ERS_D_Ld3.f19_g16.X.yellowstone_intel.cpl.hi.nc : test compare cpl.hi (.base and .rest files) 
PASS ERS_D_Ld3.f19_g16.X.yellowstone_intel : test functionality summary (ERS_test) 
PASS ERS_D_Ld3.f19_g16.X.yellowstone_intel.memleak
--- Test time is 335 seconds ---

DONE PET_D_E_CG.f19_g16.X.yellowstone_intel : (test finished, successful coupler log) 
--- Test Functionality ---:
PASS PET_D_E_CG.f19_g16.X.yellowstone_intel.cpl.hi.nc : test compare cpl.hi (.base and .1thread files) 
PASS PET_D_E_CG.f19_g16.X.yellowstone_intel : test functionality summary (PET_test) 
--- Test time is 696 seconds ---
