### PR TITLE
makes nag compatible with both goldbach and hobart

### DIFF
--- a/machines/Makefile
+++ b/machines/Makefile
@@ -286,16 +286,13 @@ ifeq ($(MODEL),driver)
 else
   ifeq ($(strip $(COMPILER)),nag)
     ifeq ($(DEBUG), TRUE)
+      ifeq ($(strip $(MACH)),hobart)
        # GCC needs to be able to link to
        # nagfor runtime to get autoconf
        # tests to work.
-       # No longer hard-coded to $(NAG), as we now have
-       # modules on goldbach. The modules on goldbach 
-       # now have $COMPILER_PATH defined, so we can 
-       # get the base path to the compiler without any 
-       # acrobatics.
-       CFLAGS += -Wl,--as-needed,--allow-shlib-undefined
-       SLIBS += -L$(COMPILER_PATH)/lib/NAG_Fortran -lf60rts
+         CFLAGS += -Wl,--as-needed,--allow-shlib-undefined
+         SLIBS += -L$(COMPILER_PATH)/lib/NAG_Fortran -lf60rts
+       endif
     endif
   endif
 endif

--- a/machines/config_compilers.xml
+++ b/machines/config_compilers.xml
@@ -877,6 +877,7 @@ for mct, etc.
  <MPI_PATH MPILIB="openmpi"> /usr/local/openmpi-gcc-nag</MPI_PATH>
  <PFUNIT_PATH>/home/santos/pFUnit/pFUnit_NAG_3_0</PFUNIT_PATH>
  <!-- needed for nag pio build.. -->
+ <ADD_FFLAGS> -kind=byte </ADD_FFLAGS>
  <ADD_CPPDEFS> -DNO_C_SIZEOF </ADD_CPPDEFS>
  <!-- Experimental wrapper for OpenMP. -->
  <ADD_LDFLAGS compile_threaded="true"> -L/home/santos/lib/fake_omp -lfake_omp -Wl,-Wl,,--rpath=/home/santos/lib/fake_omp </ADD_LDFLAGS>

--- a/machines/env_mach_specific.goldbach
+++ b/machines/env_mach_specific.goldbach
@@ -23,8 +23,8 @@ if ( $COMPILER == "pgi" ) then
 endif
 
 if ( $COMPILER == "nag" ) then
-    #module load compiler/nag/5.3.1-907
-    module load compiler/nag/6.0-test
+    module load compiler/nag/5.3.1-907
+    #module load compiler/nag/6.0-test
 endif
 
 if ( $COMPILER == "gnu" ) then

--- a/machines/env_mach_specific.hobart
+++ b/machines/env_mach_specific.hobart
@@ -1,7 +1,7 @@
 #! /bin/csh -f
 
 #===============================================================================
-# Goldbach machine specific settings
+# Hobart machine specific settings
 #===============================================================================
 setenv PATH /home/jedwards/cmake-3.2.3/bin:$PATH
 cmake --version
@@ -37,6 +37,7 @@ if ( $COMPILER == "pgi" ) then
 endif
 
 if ( $COMPILER == "nag" ) then
+    setenv MACH hobart
     module load compiler/nag/6.0
     if( $MPILIB == "mvapich2" ) then
       ./xmlchange MPILIB=openmpi


### PR DESCRIPTION
This patch allows the nag compilers on hobart and goldbach to both work.  
mpi-serial tests will not work on goldbach.nag, the recent mpi-serial is incompatible with the 
kind=byte parameter used there. 
