### PR TITLE
Reject use of OpenMP in NAG builds

### DIFF
--- a/scripts/Tools/cesm_setup
+++ b/scripts/Tools/cesm_setup
@@ -168,6 +168,10 @@ if (! $clean ) {
 	}
     }
 
+    if ($build_threaded eq "TRUE" and $xmlvars{"COMPILER"} eq "nag") {
+        die "ERROR cesm_setup: it is not possible to run with OpenMP if using the NAG Fortran compiler\n";
+    }
+
     my $sysmod = "./xmlchange BUILD_THREADED=$build_threaded";
     system($sysmod) == 0 or die "ERROR cesm_setup: $sysmod failed: $?\n";
 


### PR DESCRIPTION
Every few weeks, someone tries to run NAG with a threaded build, and we don't have a consistent error message explaining the problem with that, so people end up chasing down weird compiler error messages when the real solution is to turn off OpenMP. I figured I'd fix this by just throwing an error in `cesm_setup` if you try to do the wrong thing here.

This passes NAG tests on hobart, and I've also verified that the expected error message really is output if you use `xmlchange NTHRDS_ATM=2`.
