### PR TITLE
Fix wrong math in dynamic_vector allocation.

### DIFF
--- a/share/csm_share/include/dynamic_vector_procdef.inc
+++ b/share/csm_share/include/dynamic_vector_procdef.inc
@@ -123,7 +123,11 @@ PURE function get_range_vec(self, begin, end, stride) result(items)
   end if
 
   if (present(stride)) then
-     allocate(items(end+1-begin/stride))
+     ! For strided access, the number of elements is the size over the
+     ! stride, but rounded up, rather than down as in typical integer
+     ! division. The shortcut for this is that (x-1)/y + 1 is the same as
+     ! x/y rounded up.
+     allocate(items((end-begin)/stride + 1))
      items = self%data(begin:end:stride)
   else
      allocate(items(end+1-begin))


### PR DESCRIPTION
This is a very low impact bug, because the affected code is not currently exercised in CESM. But the issue is easy to fix.

Under some compilers, using the strided subsection feature of dynamic vectors could cause a heap array to be allocated with too small of a size, causing an out-of-bounds access issue. No one is accessing dynamic vectors with strides yet, so this does not currently cause an issue in CESM runs. We also don't run unit tests on the affected compilers, so the bug was not caught until I noticed this while trying to create a test driver for debugging an issue with the Cray compiler.
