### PR TITLE
Simplify cesm_setup script

### DIFF
--- a/scripts/Tools/cesm_setup
+++ b/scripts/Tools/cesm_setup
@@ -270,28 +270,18 @@ if (! $clean ) {
     if (!-f "./user_nl_cpl") {
 	print "Creating user_nl_xxx files for components and cpl$eol";
     }
-    my @models = qw( ATM LND ICE OCN GLC ROF WAV );
-    my @multi_support = qw(cam datm clm dlnd cice dice pop docn rtm drof cism ww3);
+    my @models = qw( ATM LND ICE OCN GLC ROF WAV CPL);
     # loop over target models
     foreach my $model (@models) {
 	# what is component for target model
 	my $comp = $xmlvars{"COMP_${model}"};
-
-	# loop over components 
-	foreach my $comp_multi (@multi_support) {
-	    # determine if component is one that has multi-instance support and 
-	    # if have multi-instance support - then create appropriate user_nl_fiels
-	    if ($comp eq $comp_multi) {
-		build_usernl_files($caseroot, $model, $comp);
-		last;
-	    }
-	}
+	build_usernl_files($caseroot, $model, $comp);
 	if ($comp eq "cism")  {
 	    my $sysmod = "$caseroot/Buildconf/cism.template $caseroot";
 	    system($sysmod) == 0 or die "ERROR cesm_setup: $sysmod failed: $?\n";
 	}
     }
-    build_usernl_files($caseroot, "drv", "cpl");
+
 
     #--------------------------------------------------------------------------
     # Run preview namelists for scripts


### PR DESCRIPTION
This change removes the list of models from cesm_setup so that the script
gets it's list from env_case.xml, this allows us to include new components
with fewer changes in the scripts.

Test suite: cime standalone yellowstone intel
Test baseline: cime2.0.9
Test namelist changes: none
Test status: bit for bit

Fixes: No issue was opened

Code review:
