### PR TITLE
Point to a pFUnit build in CESMDATAROOT for yellowstone

### DIFF
--- a/machines/config_compilers.xml
+++ b/machines/config_compilers.xml
@@ -509,7 +509,7 @@ for mct, etc.
 
 
 <compiler MACH="yellowstone" COMPILER="intel">
-  <PFUNIT_PATH>/glade/u/home/sacks/pFUnit/pFUnit3.1_Intel15.0.1_MPI</PFUNIT_PATH>
+  <PFUNIT_PATH>$ENV{CESMDATAROOT}/tools/pFUnit/pFUnit3.1_Intel15.0.1_MPI</PFUNIT_PATH>
 </compiler>
 
 <compiler MACH="yellowstone" COMPILER="pgi">


### PR DESCRIPTION
We had been using a pFUnit build in my home directory; at Jim's
request, I am moving this into CESMDATAROOT/tools

Test suite: cime unit tests on yellowstone/caldera
Test baseline: N/A
Test namelist changes: N/A
Test status: All passed

Fixes: None

Code review: None yet
