### PR TITLE
Workaround to allow cism-test_coupling cases to pass

### DIFF
--- a/scripts/Testing/Testlistxml/ExpectedTestFails.xml
+++ b/scripts/Testing/Testlistxml/ExpectedTestFails.xml
@@ -40,7 +40,6 @@
 <entry>RUN ERS_N2_Ld7.f19_g16.BHISTC5CN.yellowstone_gnu.allactive-default</entry>
 
 <entry>RUN ERS_D_Ld7.f19_g16.BTSC4L40CCMIS2R45.yellowstone_intel.allactive-default</entry>
-<entry>RUN NCK_Ld5.f19_g16.BGC5L45BGC.yellowstone_intel.allactive-cism-test_coupling</entry>
 <entry>RUN ERS.f09_g16.B1850C5CN.bluewaters_pgi</entry>
 <entry>RUN ERS_Ld7.ne16_g37.BC5.babbageKnc_intel</entry>
 <entry>RUN ERI.f09_g16.B1850C5L45BGC.bluewaters_pgi.allactive-default</entry>

--- a/scripts/Testing/Testlistxml/testmods_dirs/allactive/cism/test_coupling/user_nl_rtm
+++ b/scripts/Testing/Testlistxml/testmods_dirs/allactive/cism/test_coupling/user_nl_rtm
@@ -1,0 +1,3 @@
+! This mod is needed as a workaround for http://bugs.cgd.ucar.edu/show_bug.cgi?id=2150
+! It should be removed once that bug is fixed
+ice_runoff = .false.


### PR DESCRIPTION
Change ice runoff to liquid in cism-test_coupling cases

This is needed as a workaround for
http://bugs.cgd.ucar.edu/show_bug.cgi?id=2150, until we can fix that
bug more robustly.

Also, remove a test from the expected fail list that no longer fails, due to
this change.

Test suite: The two BG cases that use the cism-test_coupling testmods:
  SMS_D_Ld5.T31_g37_gl20.BG1850C5L45BGCIS2.yellowstone_intel.allactive-cism-test_coupling
  NCK_Ld5.f19_g16.BGC5L45BGC.yellowstone_intel.allactive-cism-test_coupling
Test baseline: cesm1_4_alpha07a
Test namelist changes: adds 'ice_runoff = .false.' for tests using
  these mods
Test status: Potentially changes answers for any tests with this testmods

Fixes: Workaround for bug 2150, but not a real fix for that bug

Code review: None yet
