### PR TITLE
Do not set CLM_FORCE_COLDSTART for glc_mec cases

### DIFF
--- a/scripts/Tools/config_compsets.xml
+++ b/scripts/Tools/config_compsets.xml
@@ -857,9 +857,6 @@ CAM[45]%L60  => CAM with 60 layers and full gravity wave spectrum:
 <CLM_CO2_TYPE compset="HIST.*_DATM"    >diagnostic</CLM_CO2_TYPE>
 <CLM_CO2_TYPE compset="RCP.*_DATM"     >diagnostic</CLM_CO2_TYPE>
 
-<CLM_FORCE_COLDSTART compset="_CLM.+CISM"        >on</CLM_FORCE_COLDSTART>
-<CLM_FORCE_COLDSTART compset="4804.*_CLM.*_CISM1">off</CLM_FORCE_COLDSTART>
-
 <!-- ======================================= -->
 <!--          USER_DEFINED section           -->
 <!-- Add new values for                      -->


### PR DESCRIPTION
It's not clear why this was ever being set, but it is undesirable: We
sometimes want to use initial conditions for glc_mec cases.

Test suite: Ran IG tests from the aux_clm40 and aux_clm45 test suites:
   SMS_Lm37.T31_g37.IG1850CLM45.yellowstone_intel.clm-glcMEC_long
   ERP.f19_g16.IG1850CLM45.yellowstone_pgi
   PEM_D.f19_g16.IG1850CLM45.yellowstone_pgi.clm-glcMEC_increase
   ERP_D_Ld5.T31_g37.IG1850CLM50.yellowstone_pgi.clm-glcMEC
   ERS_D_Ld10.T31_g37.IGHISTCLM45.yellowstone_intel.clm-glcMEC_decrease
   ERP_D_Ld5.f19_g16.ICLM45GLCMEC.yellowstone_intel.clm-glcMEC_changeFlags
   ERI_D.f19_g16.IG1850CN.yellowstone_pgi
   ERS_Lm3.f19_g16.IGRCP60CN.yellowstone_intel
Test baseline: clm4_5_1_r118
Test namelist changes: None
Test status: bit for bit

Fixes: None

Code review: None
