### PR TITLE
Clean up prints to CaseStatus

### DIFF
--- a/scripts/Tools/cesm_build.pl
+++ b/scripts/Tools/cesm_build.pl
@@ -593,7 +593,7 @@ sub buildModel()
 	print " .... locking file $file\n";
     }
     
-    my $sdate = strftime("%y%m%d-%H%M%S", localtime);
+    my $sdate = `date +"%Y-%m-%d %H:%M:%S"`;
     open my $CS, ">>", "./CaseStatus";
     print $CS "build complete $sdate\n";
     close $CS;

--- a/scripts/Tools/cesm_clean_build
+++ b/scripts/Tools/cesm_clean_build
@@ -105,4 +105,9 @@ my @lockedfiles = glob("LockedFiles/env_build*");
 foreach my $lf (@lockedfiles) {
     unlink($lf);
 }
-system("./xmlchange SMP_BUILD=0,NINST_BUILD=0,BUILD_COMPLETE=FALSE,BUILD_STATUS=0");
+system("./xmlchange -noecho SMP_BUILD=0,NINST_BUILD=0,BUILD_COMPLETE=FALSE,BUILD_STATUS=0");
+
+my $sdate = `date +"%Y-%m-%d %H:%M:%S"`;
+open my $CS, ">>", "./CaseStatus";
+print $CS "clean_build complete $sdate\n";
+close $CS;

--- a/scripts/Tools/cesm_setup
+++ b/scripts/Tools/cesm_setup
@@ -172,7 +172,7 @@ if (! $clean ) {
         die "ERROR cesm_setup: it is not possible to run with OpenMP if using the NAG Fortran compiler\n";
     }
 
-    my $sysmod = "./xmlchange BUILD_THREADED=$build_threaded";
+    my $sysmod = "./xmlchange -noecho BUILD_THREADED=$build_threaded";
     system($sysmod) == 0 or die "ERROR cesm_setup: $sysmod failed: $?\n";
 
 
@@ -305,6 +305,12 @@ if (! $clean ) {
 	    print "Finished testcase_setup \n";
 	}
     }
+
+    my $fh = new IO::File;
+    $fh->open(">>CaseStatus") or die "can't open file: CaseStatus\n";
+    my $sdate = `date +"%Y-%m-%d %H:%M:%S"`;
+    print $fh "cesm_setup $sdate $eol";
+    $fh->close();
 
 }
     


### PR DESCRIPTION
The general rules I have applied in a few places are:
- scripts like cesm_setup and the build script should print a status line to
  CaseStatus when they complete
- scripts should generally NOT echo their individual xmlchange commands to
  CaseStatus (since doing so makes it look like the user manually ran those
  xmlchange commands, when in fact they were run automatically as part of a
  script whose running is already documented in CaseStatus)

Also changed the format of the time-stamp printed by the build script to be
consistent with other time-stamps printed to CaseStatus.

Test suite: drv prealpha yellowstone
Test baseline: cesm1_4_alpha07b
Test namelist changes: none
Test status: bit for bit

Fixes: None

Code review: None
