### PR TITLE
Add LII test to test CLM online interpolation

### DIFF
--- a/scripts/Testing/Testcases/LII_build.csh
+++ b/scripts/Testing/Testcases/LII_build.csh
@@ -13,7 +13,7 @@ if ( ! -e user_nl_nointerp ) then
     cp user_nl_clm* user_nl_nointerp
     foreach file (user_nl_nointerp/user_nl_clm*)
 	# False is the default, but set it explicitly to be sure
-    	echo "force_init_interp = .false." >> $file
+    	echo "use_init_interp = .false." >> $file
     end
 endif
 
@@ -21,7 +21,7 @@ if ( ! -e user_nl_interp ) then
     mkdir user_nl_interp
     cp user_nl_clm* user_nl_interp
     foreach file (user_nl_interp/user_nl_clm*)
-    	echo "force_init_interp = .true." >> $file
+    	echo "use_init_interp = .true." >> $file
     end
 endif
 

--- a/scripts/Testing/Testcases/LII_build.csh
+++ b/scripts/Testing/Testcases/LII_build.csh
@@ -1,0 +1,43 @@
+#!/bin/csh -f
+
+# Make copies of the namelist files for each part of the test. Enclose the
+# copies in conditionals so that we only do this namelist setup the first time
+# the build script is invoked - otherwise, if the build is rerun, the namelist
+# files would build up repeated instances of the setting of force_init_intep.
+#
+# Note the use of shell wildcards to make sure we apply these mods to
+# multi-instance versions
+
+if ( ! -e user_nl_nointerp ) then
+    mkdir user_nl_nointerp
+    cp user_nl_clm* user_nl_nointerp
+    foreach file (user_nl_nointerp/user_nl_clm*)
+	# False is the default, but set it explicitly to be sure
+    	echo "force_init_interp = .false." >> $file
+    end
+endif
+
+if ( ! -e user_nl_interp ) then
+    mkdir user_nl_interp
+    cp user_nl_clm* user_nl_interp
+    foreach file (user_nl_interp/user_nl_clm*)
+    	echo "force_init_interp = .true." >> $file
+    end
+endif
+
+
+# The actual build for this test is the same as for the standard test, so the
+# contents of test_build.csh are copied below:
+
+./Tools/check_lockedfiles || exit -1
+
+# NOTE - Are assumming that are already in $CASEROOT here
+set CASE     = `./xmlquery CASE    -value`
+
+./$CASE.build
+if ($status != 0) then
+   echo "Error: build failed" >! ./TestStatus
+   echo "CFAIL $CASE" > ./TestStatus
+   exit -1    
+endif 
+

--- a/scripts/Testing/Testcases/LII_script
+++ b/scripts/Testing/Testcases/LII_script
@@ -1,0 +1,108 @@
+
+#======================================================================
+# Setup
+#======================================================================
+
+cd $CASEROOT
+
+set STOP_N      = `./xmlquery STOP_N      -value`
+set STOP_OPTION = `./xmlquery STOP_OPTION -value`
+
+./xmlchange -file env_run.xml -id CONTINUE_RUN -val FALSE
+./xmlchange -file env_run.xml -id HIST_OPTION  -val ${STOP_OPTION}
+./xmlchange -file env_run.xml -id HIST_N       -val ${STOP_N}
+
+#======================================================================
+# do a run with force_init_interp false
+#======================================================================
+
+cd $CASEROOT
+
+echo "doing an ${STOP_N} ${STOP_OPTION} test with force_init_interp false" >>& $TESTSTATUS_LOG 
+
+cp user_nl_nointerp/* .
+
+./$CASE.run
+if ($status != 0) then
+    echo " ERROR: $CASE.run failed" >>& $TESTSTATUS_LOG
+    exit -1
+endif
+
+set CplLogFile = `ls -1t $RUNDIR/cpl.log* | head -1`
+if ( $?CplLogFile ) then
+    if (-e $CplLogFile) then
+       set pass = `zgrep "SUCCESSFUL TERMINATION" $CplLogFile | wc -l`
+       if ($pass != 1) then
+           echo "ERROR: coupler log $CplLogFile indicates model run failed" >>& $TESTSTATUS_LOG 
+ 	   exit -1
+       else 
+           echo "Success: test log is $CplLogFile" >>& $TESTSTATUS_LOG 
+       endif
+    endif
+else
+    echo "ERROR: no coupler log created, model run failed" >>& $TESTSTATUS_LOG
+    exit -1
+endif
+
+echo "" >>& $TESTSTATUS_LOG
+echo "moving relevant history files to suffix with command " >>& $TESTSTATUS_LOG
+echo "$SCRIPTSROOT/Tools/component_compare_move.sh -rundir $RUNDIR -testcase $CASE -suffix base $add_iop" >>& $TESTSTATUS_LOG
+echo "" >>& $TESTSTATUS_LOG
+
+$SCRIPTSROOT/Tools/component_compare_move.sh -rundir $RUNDIR -testcase $CASE -suffix "base" $add_iop
+
+
+#======================================================================
+# do a run with force_init_interp true
+#======================================================================
+
+cd $CASEROOT
+
+echo "doing an ${STOP_N} ${STOP_OPTION} test with force_init_interp true" >>& $TESTSTATUS_LOG 
+
+cp user_nl_interp/* .
+
+./$CASE.run
+if ($status != 0) then
+    echo " ERROR: $CASE.run failed" >>& $TESTSTATUS_LOG
+    exit -1
+endif
+
+set CplLogFile = `ls -1t $RUNDIR/cpl.log* | head -1`
+if ( $?CplLogFile ) then
+    if (-e $CplLogFile) then
+       set pass = `zgrep "SUCCESSFUL TERMINATION" $CplLogFile | wc -l`
+       if ($pass != 1) then
+           echo "ERROR: coupler log $CplLogFile indicates model run failed" >>& $TESTSTATUS_LOG 
+ 	   exit -1
+       else 
+           echo "Success: test log is $CplLogFile" >>& $TESTSTATUS_LOG 
+       endif
+    endif
+else
+    echo "ERROR: no coupler log created, model run failed" >>& $TESTSTATUS_LOG
+    exit -1
+endif
+
+echo "" >>& $TESTSTATUS_LOG
+echo "moving relevant history files to suffix with command " >>& $TESTSTATUS_LOG
+echo "$SCRIPTSROOT/Tools/component_compare_move.sh -rundir $RUNDIR -testcase $CASE -suffix interp $add_iop" >>& $TESTSTATUS_LOG
+echo ""	>>& $TESTSTATUS_LOG
+
+$SCRIPTSROOT/Tools/component_compare_move.sh -rundir $RUNDIR -testcase $CASE -suffix interp $add_iop
+
+#======================================================================
+# Test status check:
+#======================================================================
+
+set CPLLOG = $CplLogFile
+
+if ! ( $?IOP_ON ) then
+    echo "DONE ${CASEBASEID} : (test finished, successful coupler log) " >&! $TESTSTATUS_OUT
+    echo "--- Test Functionality  ---:" >>& $TESTSTATUS_OUT
+endif
+
+echo "DONE ${CASEBASEID} : ($msg finished, successful coupler log) " >>& $TESTSTATUS_LOG
+echo "" >>& $TESTSTATUS_LOG
+
+$SCRIPTSROOT/Tools/component_compare_test.sh -rundir $RUNDIR -testcase $CASE -testcase_base $CASEBASEID -suffix1 base -suffix2 interp $add_iop -msg "$msg" >>& $TESTSTATUS_OUT

--- a/scripts/Testing/Testcases/LII_script
+++ b/scripts/Testing/Testcases/LII_script
@@ -13,12 +13,12 @@ set STOP_OPTION = `./xmlquery STOP_OPTION -value`
 ./xmlchange -file env_run.xml -id HIST_N       -val ${STOP_N}
 
 #======================================================================
-# do a run with force_init_interp false
+# do a run with use_init_interp false
 #======================================================================
 
 cd $CASEROOT
 
-echo "doing an ${STOP_N} ${STOP_OPTION} test with force_init_interp false" >>& $TESTSTATUS_LOG 
+echo "doing an ${STOP_N} ${STOP_OPTION} test with use_init_interp false" >>& $TESTSTATUS_LOG 
 
 cp user_nl_nointerp/* .
 
@@ -53,12 +53,12 @@ $SCRIPTSROOT/Tools/component_compare_move.sh -rundir $RUNDIR -testcase $CASE -su
 
 
 #======================================================================
-# do a run with force_init_interp true
+# do a run with use_init_interp true
 #======================================================================
 
 cd $CASEROOT
 
-echo "doing an ${STOP_N} ${STOP_OPTION} test with force_init_interp true" >>& $TESTSTATUS_LOG 
+echo "doing an ${STOP_N} ${STOP_OPTION} test with use_init_interp true" >>& $TESTSTATUS_LOG 
 
 cp user_nl_interp/* .
 

--- a/scripts/Testing/Testcases/config_tests.xml
+++ b/scripts/Testing/Testcases/config_tests.xml
@@ -74,6 +74,13 @@
           CCSM_TCOST="4"
           DOUT_L_MS="TRUE" />
 
+<ccsmtest NAME="LII"
+          DESC="CLM initial condition interpolation test (requires configuration with non-blank finidat)"
+          INFO_DBUG="1"
+          CCSM_TCOST="0"
+          REST_OPTION="none"
+          DOUT_S="FALSE" />
+
 <ccsmtest NAME="PEA"
           DESC="single pe bfb test (default length)"
           INFO_DBUG="1"


### PR DESCRIPTION
This is a test specific to CLM, to ensure that the online interpolation
works properly, at least in a basic sense: It ensures that, when
interpolating an initial conditions file onto a run with the same
configuration and resolution, results are bit-for-bit with a run that
did not do any interpolation.

Test suite: None
Test baseline: N/A
Test namelist changes: N/A
Test status: N/A

I ran a few tests to confirm that this passes when it should pass, and
fails when it should fail (by intentionally breaking the
interpolation). I also confirmed that it works properly if you rebuild
and rerun it.

Specifically, I ran:

LII_D.f19_g16.I1850CLM45BGC.yellowstone_intel.clm-default
LII_D.f10_f10.ICLM45BGCCROP.yellowstone_intel.clm-crop

Both passed.

But with this diff, the above f19_g16 test failed appropriately:

``` diff
--- ../../../components/clm/src/biogeophys/WaterStateType.F90   2015-08-26 13:46:29.318485838 -0600
+++ SourceMods/src.clm/WaterStateType.F90   2015-08-30 15:33:07.991018115 -0600
@@ -811,7 +811,7 @@
     call restartvar(ncid=ncid, flag=flag, varname='H2OSFC', xtype=ncd_double,  &
          dim1name='column', &
          long_name='surface water', units='kg/m2', &
-         interpinic_flag='interp', readvar=readvar, data=this%h2osfc_col)
+         interpinic_flag='skip', readvar=readvar, data=this%h2osfc_col)
     if (flag=='read' .and. .not. readvar) then
        this%h2osfc_col(bounds%begc:bounds%endc) = 0.0_r8
     end if
```

Fixes: None

Code review: None
