### PR TITLE
pio2 compatibility issues and remove debug prints

### DIFF
--- a/driver_cpl/driver/cpl_comp_esmf.F90
+++ b/driver_cpl/driver/cpl_comp_esmf.F90
@@ -40,7 +40,7 @@ CONTAINS
 
     rc = ESMF_SUCCESS
 
-    print *, "In seq map register routine"
+
     ! Register the callback routines.
 
     call ESMF_GridCompSetEntryPoint(comp, ESMF_METHOD_INITIALIZE, &

--- a/driver_cpl/driver/seq_io_mod.F90
+++ b/driver_cpl/driver/seq_io_mod.F90
@@ -507,8 +507,9 @@ end function seq_io_sec2hms
     if (lwdata) then
        call mct_gsmap_OrderedPoints(gsmap, iam, Dof)
        call pio_initdecomp(cpl_io_subsystem, pio_double, (/lnx,lny/), dof, iodesc)
+       ns = size(dof)
        deallocate(dof)
-       allocate(tmpdata(lnx*lny))
+       allocate(tmpdata(ns))
        do k = 1,nf
           call mct_aVect_getRList(mstring,k,AV)
           itemc = mct_string_toChar(mstring)

--- a/driver_cpl/driver/seq_map_esmf.F90
+++ b/driver_cpl/driver/seq_map_esmf.F90
@@ -39,7 +39,6 @@ subroutine seq_map_esmf_register(comp, rc)
 
     rc = ESMF_SUCCESS
 
-    print *, "In seq map register routine"
     ! Register the callback routines.
 
     call ESMF_GridCompSetEntryPoint(comp, ESMF_METHOD_INITIALIZE, &

--- a/externals/pio/pio/piolib_mod.F90
+++ b/externals/pio/pio/piolib_mod.F90
@@ -383,11 +383,12 @@ contains
 !! @param method :
 !! @copydoc PIO_error_method
 !<
-  subroutine seterrorhandlingf(file, method)
+  subroutine seterrorhandlingf(file, method, oldmethod)
     type(file_desc_t), intent(inout) :: file
     integer, intent(in) :: method
+    integer, optional, intent(out) :: oldmethod
 
-    call seterrorhandlingi(file%iosystem, method)
+    call seterrorhandlingi(file%iosystem, method, oldmethod)
   end subroutine seterrorhandlingf
 
 !>
@@ -398,11 +399,12 @@ contains
 !! @param method :
 !! @copydoc PIO_error_method
 !<
-  subroutine seterrorhandlingi(ios, method)
+  subroutine seterrorhandlingi(ios, method, oldmethod)
     use pio_types, only : pio_internal_error, pio_return_error
     use pio_msg_mod, only : pio_msg_seterrorhandling
     type(iosystem_desc_t), intent(inout) :: ios
     integer, intent(in) :: method
+    integer, intent(out), optional :: oldmethod
     integer :: msg, ierr
 
     if(ios%async_interface .and. .not. ios%ioproc ) then
@@ -411,6 +413,7 @@ contains
        call MPI_BCAST(method,1,MPI_INTEGER,ios%CompMaster, ios%my_comm , ierr)
     end if
     if(Debugasync) print *,__PIO_FILE__,__LINE__,method
+    if(present(oldmethod)) oldmethod = ios%error_handling
     ios%error_handling=method
 
     if(method > PIO_internal_error .or. method < PIO_return_error) then

--- a/machines/Makefile
+++ b/machines/Makefile
@@ -700,6 +700,10 @@ ULIBDEP += $(CSMSHARELIB)
 ifeq ($(MPILIB),mpi-serial)
   MPISERIAL = $(MCT_LIBDIR)/mpi-serial/libmpi-serial.a
   MLIBS += $(MPISERIAL)
+  CMAKE_OPTS += -DMPI_C_INCLUDE_PATH=$(SHAREDPATH)/include \
+      -DMPI_Fortran_INCLUDE_PATH=$(SHAREDPATH)/include \
+      -DMPI_C_LIBRARIES=$(SHAREDPATH)/lib/libmpi-serial.a \
+      -DMPI_Fortran_LIBRARIES=$(SHAREDPATH)/lib/libmpi-serial.a 
 endif
 
 $(MCTLIBS)  : $(MPISERIAL)


### PR DESCRIPTION
Add optional oldmethod argument to pio_seterrorhandling.
Remove some debug print statements
Add cmake arguments for build with mpi-serial

Test suite: drv intel yellowstone
Test baseline:
Test namelist changes:
Test status: bfb

Fixes:
Code review:
