### PR TITLE
Add dot before xmlchange commands

### DIFF
--- a/scripts/Testing/Testcases/PET_build.csh
+++ b/scripts/Testing/Testcases/PET_build.csh
@@ -26,35 +26,35 @@ set NTHRDS_CPL  = `./xmlquery NTHRDS_CPL  -value`
 
 if ( $NTHRDS_ATM <= 1) then
   echo "WARNING: component ATM is not threaded, changing NTHRDS_ATM to 2" 
-  xmlchange -file env_mach_pes.xml -id NTHRDS_ATM -val 2
+  ./xmlchange -file env_mach_pes.xml -id NTHRDS_ATM -val 2
 endif
 if ( $NTHRDS_LND <= 1) then
   echo "WARNING: component LND is not threaded, changing NTHRDS_LND to 2" 
-  xmlchange -file env_mach_pes.xml -id NTHRDS_LND -val 2
+  ./xmlchange -file env_mach_pes.xml -id NTHRDS_LND -val 2
 endif
 if ( $NTHRDS_ROF <= 1) then
   echo "WARNING: component ROF is not threaded, changing NTHRDS_ROF to 2" 
-  xmlchange -file env_mach_pes.xml -id NTHRDS_ROF -val 2
+  ./xmlchange -file env_mach_pes.xml -id NTHRDS_ROF -val 2
 endif
 if ( $NTHRDS_ICE <= 1) then
   echo "WARNING: component ICE is not threaded, changing NTHRDS_ICE to 2" 
-  xmlchange -file env_mach_pes.xml -id NTHRDS_ICE -val 2
+  ./xmlchange -file env_mach_pes.xml -id NTHRDS_ICE -val 2
 endif
 if ( $NTHRDS_OCN <= 1) then
   echo "WARNING: component OCN is not threaded, changing NTHRDS_OCN to 2" 
-  xmlchange -file env_mach_pes.xml -id NTHRDS_OCN -val 2
+  ./xmlchange -file env_mach_pes.xml -id NTHRDS_OCN -val 2
 endif
 if ( $NTHRDS_GLC <= 1) then
   echo "WARNING: component GLC is not threaded, changing NTHRDS_GOC to 2" 
-  xmlchange -file env_mach_pes.xml -id NTHRDS_GLC -val 2
+  ./xmlchange -file env_mach_pes.xml -id NTHRDS_GLC -val 2
 endif
 if ( $NTHRDS_CPL <= 1) then
   echo "WARNING: component CPL is not threaded, changing NTHRDS_CPL to 2" 
-  xmlchange -file env_mach_pes.xml -id NTHRDS_CPL -val 2
+  ./xmlchange -file env_mach_pes.xml -id NTHRDS_CPL -val 2
 endif
 if ( $NTHRDS_WAV <= 1) then
   echo "WARNING: component WAV is not threaded, changing NTHRDS_WAV to 2" 
-  xmlchange -file env_mach_pes.xml -id NTHRDS_WAV -val 2
+  ./xmlchange -file env_mach_pes.xml -id NTHRDS_WAV -val 2
 endif
 
 cp -f env_mach_pes.xml env_mach_pes.xml.1


### PR DESCRIPTION
If you don't have dot in your path, the xmlchange commands in PET_build didn't
work. Changing them to ./xmlchange fixes the problem.

Test suite: PET_D_E_CG.f19_g16.X.yellowstone_intel
Test baseline: cesm1_4_alpha07e
Test namelist changes: none
Test status: bit for bit

Fixes: None

Code review: None yet
