### PR TITLE
Add topographic height field from ATM to LND

### DIFF
--- a/driver_cpl/driver/cesm_comp_mod.F90
+++ b/driver_cpl/driver/cesm_comp_mod.F90
@@ -428,7 +428,8 @@ module cesm_comp_mod
    character(CL) :: hist_a2x_flds     = 'Faxa_swndr:Faxa_swvdr:Faxa_swndf:Faxa_swvdf'
 !  character(CL) :: hist_a2x24hr_flds = 'all'
    character(CL) :: hist_a2x3hrp_flds = 'Faxa_rainc:Faxa_rainl:Faxa_snowc:Faxa_snowl'
-   character(CL) :: hist_a2x3hr_flds  = 'Sa_z:Sa_u:Sa_v:Sa_tbot:Sa_ptem:Sa_shum:Sa_dens:Sa_pbot:Sa_pslv:Faxa_lwdn:&
+   character(CL) :: hist_a2x3hr_flds  = &
+        'Sa_z:Sa_topo:Sa_u:Sa_v:Sa_tbot:Sa_ptem:Sa_shum:Sa_dens:Sa_pbot:Sa_pslv:Faxa_lwdn:&
         &Faxa_rainc:Faxa_rainl:Faxa_snowc:Faxa_snowl:&
         &Faxa_swndr:Faxa_swvdr:Faxa_swndf:Faxa_swvdf'
 

--- a/driver_cpl/shr/seq_flds_mod.F90
+++ b/driver_cpl/shr/seq_flds_mod.F90
@@ -539,6 +539,15 @@ module seq_flds_mod
      attname  = 'Sa_z'
      call metadata_set(attname, longname, stdname, units)
 
+     ! topographic height (m)
+     call seq_flds_add(a2x_states,"Sa_topo")
+     call seq_flds_add(x2l_states,"Sa_topo")
+     longname = 'Surface height'
+     stdname  = 'height'
+     units    = 'm'
+     attname  = 'Sa_topo'
+     call metadata_set(attname, longname, stdname, units)
+
      ! zonal wind at the lowest model level (m/s)
      call seq_flds_add(a2x_states,"Sa_u")
      call seq_flds_add(x2l_states,"Sa_u")


### PR DESCRIPTION
Test suite: yellowstone prealpha drv
Test baseline: cesm1_4_alpha07e
Test namelist changes: none
Test status: changes answers for X compsets, otherwise bit for bit

Also ran the following tests out of
https://svn-ccsm-models.cgd.ucar.edu/cam1/branch_tags/pass_topographic_height_tags/pass_topographic_height_n01_cam5_4_14,
and checked the Sa_topo field:
SMS_Ln9_D.f19_f19.FC5.yellowstone_intel
SMS_Ln9_D.ne16_ne16.FC5.yellowstone_intel
SMS_Ln9_D_P60x1.T31_T31.FC5.yellowstone_intel

Fixes: None

Code review: None yet
