### PR TITLE
Update to pgi/14.10.0 on bluewaters

### DIFF
--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -308,7 +308,7 @@
       </modules>
       <modules compiler="pgi">
 	<command name="load">PrgEnv-pgi</command>
-	<command name="switch">pgi pgi/14.2.0</command>
+	<command name="switch">pgi pgi/14.10.0</command>
       </modules>
       <modules compiler="gnu">
 	<command name="load">PrgEnv-gnu/4.2.84</command>


### PR DESCRIPTION
Test ERS.f09_g16.B1850C5CN.bluewaters_pgi.allactive_default on bluewaters failed
with compiler error:
ILM FILE line 86459: Bad ilm operand 0
PGF90-F-0000-Internal compiler error. Errors in ILM file 1
This is fixed in later versions of the PGI compiler including 14.10.0 so updated the default
pgi compiler version for bluewaters

Test suite: cesm1_5_alpha01 - prealpha
Test baseline: cesm1_4_alpha07e
Test namelist changes: N/A
Test status: bit for bit

Fixes: CIME Github issue #170

Code review: jedwards
