### PR TITLE
Fix cime #103, adding none option as a valid 'fillalgo'

### DIFF
--- a/components/data_comps/docn/bld/namelist_files/namelist_definition_docn.xml
+++ b/components/data_comps/docn/bld/namelist_files/namelist_definition_docn.xml
@@ -83,12 +83,12 @@ for all input data for this strdata input.
 type="char*256(30)"  
 category="streams"
 group="shr_strdata_nml"
-valid_values="copy,bilinear,nn,nnoni,nnonj,spval">
+valid_values="copy,none,bilinear,nn,nnoni,nnonj,spval">
 array (up to 30 elements) of fill algorithms associated with the array
 of streams.  valid options are just copy (ie. no fill), special value,
 nearest neighbor, nearest neighbor in "i" direction, or nearest
 neighbor in "j" direction.
-valid values:  'copy','spval','nn','nnoni','nnonj'  
+valid values:  'copy','none','spval','nn','nnoni','nnonj'  
 default: "nn".
 </entry>
 


### PR DESCRIPTION
adding none option as a valid fillalgo
docn/bld/namelist_files/namelist_definition_docn.xml

Test suite: N/A
Test baseline: N/A
Test namelist changes: may see diffs in docn cases, but unlikely unless
this option is enabled by hand.
Test status: bit for bit

Fixes: #103

Code review: N/A
