### PR TITLE
Allow more than two test configure options

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -1020,7 +1020,7 @@ sub ParseTestName
 
   # get configuration options for the test
   # keep the underscore at the start of the string
-  my @conftest = split(/(_)/, $testhash->{'testname'}, 3);
+  my @conftest = split(/(_)/, $testhash->{'testname'});
   $testhash->{'fullname'} = $testhash->{'testname'};
   $testhash->{'testname'} = shift @conftest;
   foreach my $coptions (@conftest){


### PR DESCRIPTION
create_test was not parsing a test name with more than two
options correctly.

Test suite:  SBN yellowstone intel
Test baseline: none
Test namelist changes:
Test status: bfb

Fixes: #196

Code review:
