### PR TITLE
CASEROOT bug in tests introduced in cime3.0.10

### DIFF
--- a/scripts/Tools/testcase_setup
+++ b/scripts/Tools/testcase_setup
@@ -194,7 +194,7 @@ my $testcase_interp = <<END_INTERP;
     # (Don't) Remove test status files! create_test puts the namelist comparision 
     # status and output into these files, respectively.  
     #======================================================================
-
+    set CASEROOT            = $caseroot
     set CASE			=  $case
     set CASEBASEID		=  $casebaseid
     set TEST_TESTID		=  $test_testid 


### PR DESCRIPTION
The CASEROOT variable is missing from test csh scripts

Test suite: yellowstone drv intel prealpha
Test baseline: none
Test namelist changes: none
Test status: bit for bit

Fixes: #203

Code review:
