### PR TITLE
Fixes to cime3.2.4

### DIFF
--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -38,25 +38,25 @@
 
   <!-- 1850 compsets Default, Mosart, Wave for CESM2 -->
 
-  <COMPSET>
+  <compset>
     <alias>B1850</alias>
     <lname>1850_CAM5_CLM50%BGC_CICE_POP2_RTM_SGLC_SWAV</lname>
-  </COMPSET>
+  </compset>
 
-  <COMPSET>
+  <compset>
     <alias>BM1850</alias>
     <lname>1850_CAM5_CLM50%BGC_CICE_POP2_MOSART_SGLC_SWAV</lname>
-  </COMPSET>
+  </compset>
 
-  <COMPSET>
+  <compset>
     <alias>BW1850</alias>
     <lname>1850_CAM5_CLM50%BGC_CICE_POP2_RTM_SGLC_DWAV</lname>
-  </COMPSET>
+  </compset>
 
-  <COMPSET>
+  <compset>
     <alias>BMW1850</alias>
     <lname>1850_CAM5_CLM50%BGC_CICE_POP2_MOSART_SGLC_DWAV</lname>
-  </COMPSET>
+  </compset>
 
   <!-- Other B compsets -->
 

--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -8,7 +8,7 @@
       </test>
     </grid>
     <grid name="f45_g37">
-      <test name="PEA_P1_M">
+      <test name="PEA_P1">
         <machine compiler="intel" testtype="prebeta" testmods="allactive/default">hobart</machine>
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/default">hobart</machine>
       </test>
@@ -25,7 +25,6 @@
     <grid name="f19_g16">
       <test name="ERS_Ld11">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/default">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/default">yellowstone</machine>
       </test>
     </grid>
   </compset>
@@ -53,23 +52,18 @@
     </grid>
   </compset>
   <compset name="B1850C5L45BGC">
-    <grid name="T31_g37">
+    <grid name="f19_g16">
       <test name="CME_D_Ld5">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/default">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/default">yellowstone</machine>
       </test>
       <test name="CME_Ld5">
         <machine compiler="intel" testtype="prebeta" testmods="allactive/default">edison</machine>
       </test>
       <test name="ERS_E_Ld7">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/default">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/default">yellowstone</machine>
       </test>
-    </grid>
-    <grid name="T31_g37">
       <test name="NCR_P4x1D">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/default">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/default">yellowstone</machine>
       </test>
     </grid>
     <grid name="f09_g16">
@@ -88,12 +82,10 @@
       <test name="ERS_D_Ld7">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/default">bluewaters</machine>
         <machine compiler="intel" testtype="prealpha" testmods="allactive/default">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/default">yellowstone</machine>
       </test>
       <test name="PET_PT">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/default">titan</machine>
         <machine compiler="gnu" testtype="prealpha" testmods="allactive/default">yellowstone</machine>
-        <machine compiler="gnu" testtype="prebeta" testmods="allactive/default">yellowstone</machine>
       </test>
     </grid>
     <grid name="ne120_g16">
@@ -104,14 +96,12 @@
     <grid name="ne30_g16">
       <test name="ERI">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/default">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/default">yellowstone</machine>
       </test>
       <test name="ERS_D_Ld7">
         <machine compiler="ibm" testtype="prebeta" testmods="allactive/default">mira</machine>
       </test>
       <test name="ERS_IOP_Ld7">
         <machine compiler="ibm" testtype="prebeta" testmods="allactive/default">mira</machine>
-        <machine compiler="gnu" testtype="prealpha" testmods="allactive/default">yellowstone</machine>
         <machine compiler="gnu" testtype="prebeta" testmods="allactive/default">yellowstone</machine>
       </test>
       <test name="ERS_Ld7">
@@ -132,7 +122,7 @@
     </grid>
   </compset>
   <compset name="B1850CN">
-    <grid name="T31_g37">
+    <grid name="f09_g16">
       <test name="NOC">
         <machine compiler="intel" testtype="prealpha">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
@@ -193,6 +183,13 @@
       </test>
     </grid>
   </compset>
+  <compset name="B1850C5L45BG">
+    <grid name="T31_g37">
+      <test name="ERS_Ld5">
+        <machine compiler="intel" testtype="prealpha" testmods="allactive/cism/test_coupling">yellowstone</machine>
+      </test>
+    </grid>
+  </compset>
   <compset name="BG1850C5L45BGCIS2">
     <grid name="T31_g37_gl20">
       <test name="SMS_D_Ld5">
@@ -249,7 +246,6 @@
   <compset name="BMOZ">
     <grid name="f45_g37">
       <test name="ERS_Ld7">
-        <machine compiler="gnu" testtype="prealpha" testmods="allactive/default">yellowstone</machine>
         <machine compiler="gnu" testtype="prebeta" testmods="allactive/default">yellowstone</machine>
       </test>
     </grid>

--- a/driver_cpl/cime_config/testdefs/testlist_drv.xml
+++ b/driver_cpl/cime_config/testdefs/testlist_drv.xml
@@ -78,7 +78,7 @@
         <machine compiler="intel" testtype="prebeta">edison</machine>
         <machine compiler="intel" testtype="prebeta">eos</machine>
       </test>
-      <test name="PEA_P1_M_Ld3">
+      <test name="PEA_P1_Ld3">
         <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
         <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
@@ -135,7 +135,7 @@
   </compset>
   <compset name="X">
     <grid name="T31_g37">
-      <test name="PEA_P1_M_Ld3">
+      <test name="PEA_P1_Ld3">
         <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta">yellowstone</machine>
         <machine compiler="pgi" testtype="prebeta">yellowstone</machine>

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -483,15 +483,19 @@ if (!$opts{'user_compset'}) {
 # Special case - if land and river grids are different AND there is no mapping file
 # between land and river then set the river mode  to null if the river component is rtm
 my $rof_comp = $config->get('COMP_ROF');
-if ($rof_comp eq 'rtm') {
+if ($rof_comp eq 'rtm' || $rof_comp eq 'mosart') {
     my $lnd_grid    = $config->get('LND_GRID');
     my $rof_grid    = $config->get('ROF_GRID');
     my $map_lnd2rof = $config->get('LND2ROF_FMAPNAME');
     
     if (($lnd_grid ne $rof_grid) && ($map_lnd2rof eq 'idmap')) {
 	$logger->warn("No lnd2rof_fmapname exists - RTM/MOSART mode set to null \n");
-	$config->set('RTM_MODE', 'NULL');     
-	$config->set('MOSART_MODE', 'NULL');     
+	if ($rof_comp eq 'rtm') {
+	    $config->set('RTM_MODE', 'NULL');     
+	}
+	if ($rof_comp eq 'mosart') {
+	    $config->set('MOSART_MODE', 'NULL');     
+	}
     }
 }
 


### PR DESCRIPTION
These were to to fix prealpha and prebeta test failures
as well as to clean up duplicate tests

As of this patch -
with the externals for cesm1_5_alpha02a -
the following runtime failures still existed and need to be resolved

PET_PT.f19_g16.B1850C5L45BGC.yellowstone_gnu.allactive-default
ERS_IOP_Ld7.ne30_g16.B1850C5L45BGC.yellowstone_gnu.allactive-default
ERI.ne30_g16.B1850C5L45BGC.yellowstone_intel.allactive-default
NCR_P4x1D.T31_g37.B1850C5L45BGC.yellowstone_intel.allactive-default
ERS_Ld7.f45_g37.BMOZ.yellowstone_gnu.allactive-default
ERS.T62_g16.CECO.yellowstone_gnu.pop-ecosys

Test suite: yellowstone prealpha and prebeta
Test baseline: cesm1_5_alpha01e
Test namelist changes: none
Test status: allmost all of the tests had baseline failures (as expected)

Fixes: none of these fixes were entered as bugs
