### PR TITLE
add PBS_O_WORKDIR fix for st,lt_archive scripts

### DIFF
--- a/cime_config/cesm/machines/template.ltarchive
+++ b/cime_config/cesm/machines/template.ltarchive
@@ -10,6 +10,11 @@ use XML::LibXML;
 #------------------------------------------------------------------------------
 {{ batchdirectives }}
 
+if(defined $ENV{'PBS_O_WORKDIR'})
+{
+    chdir $ENV{'PBS_O_WORKDIR'};
+}
+
 my $scriptname = $0;
 my %config;
 my $caseroot = `./xmlquery -value CASEROOT`;

--- a/cime_config/cesm/machines/template.starchive
+++ b/cime_config/cesm/machines/template.starchive
@@ -3,6 +3,11 @@
 # Batch system directives
 #------------------------------------------------------------------------------
 {{ batchdirectives }}
+if(defined $ENV{'PBS_O_WORKDIR'})
+{
+	chdir $ENV{'PBS_O_WORKDIR'};
+}
+
 
 my $scriptname = $0;
 my $caseroot = `./xmlquery -value CASEROOT`;


### PR DESCRIPTION
Add chdir to PBS_O_WORKDIR workaround to the short-
term and long-term archive scripts so that the ERR test will work

Test suite: ERR test on Eos, Yellowstone both pass
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes: n/a

Code review: n/a
