### PR TITLE
xmlchange / query now look in env_batch.xml

### DIFF
--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -156,7 +156,7 @@ if ( ! defined($settinglist) ) {
 }
 
 # If filename is input as option - check that it is supported
-my @filenames = qw(env_run.xml env_build.xml env_case.xml env_mach_pes.xml);
+my @filenames = qw(env_run.xml env_build.xml env_case.xml env_mach_pes.xml env_batch.xml);
 if ( ! defined($settinglist) ) {
    push (@filenames, $opts{'file'});
    my $status = 0;

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -147,7 +147,7 @@ sub _listids
     my %xmlvars;
     my %xmlfile;
     my @files = ('env_build.xml', 'env_case.xml', 'env_mach_pes.xml', 
-		 'env_mach_specific.xml', 'env_run.xml', 'env_test.xml'); 
+		 'env_mach_specific.xml', 'env_run.xml', 'env_test.xml', 'env_batch.xml'); 
     foreach my $file (@files) {
 	if (-f $file) {
 	    $logger->debug("Reading $file");


### PR DESCRIPTION
env_batch.xml was not in the list of files that xmlchange or xmlquery would
look in, so commands like

$ ./xmlchange JOB_WALLCLOCK_TIME=1:00

and

$ ./xmlquery JOB_WALLCLOCK_TIME

both failed.

See ticket #251
