### PR TITLE
Change CISM default grid to gland5UM

### DIFF
--- a/cime_config/cesm/config_grids.xml
+++ b/cime_config/cesm/config_grids.xml
@@ -180,13 +180,13 @@
     <grid compset="CISM1.+SWAV">
       <sname>0.9x1.25_gx1v6</sname>
       <alias>f09_g16</alias>
-      <lname>a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5_w%null</lname>
+      <lname>a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null</lname>
     </grid>
 
     <grid compset="CISM1.+DWAV">
       <sname>0.9x1.25_gx1v6</sname>
       <alias>f09_g16</alias>
-      <lname>a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5_w%ww3a</lname>
+      <lname>a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%ww3a</lname>
     </grid>
 
     <grid compset="SGLC.+DWAV">
@@ -204,12 +204,12 @@
     <grid compset="CISM1.+SWAV">
       <sname>1.9x2.5_gx1v6</sname>
       <alias>f19_g16</alias>
-      <lname>a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_m%gx1v6_g%gland5_w%null</lname>
+      <lname>a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null</lname>
     </grid>
     <grid compset="CISM1.+DWAV">
       <sname>1.9x2.5_gx1v6</sname>
       <alias>f19_g16</alias>
-      <lname>a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_m%gx1v6_g%gland5_w%ww3a</lname>
+      <lname>a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%ww3a</lname>
     </grid>
     <grid compset="SGLC.+DWAV">
       <sname>1.9x2.5_gx1v6</sname>


### PR DESCRIPTION
For resolutions where CISM grid isn't explicitly specified, it was incorrectly
given as gland5 rather than gland5UM. This is fixed here.

Test suite: Examined GRID and GLC_GRID xml variables and confirmed them to be
correct (gland5UM) for SMS.f09_g16.TG.yellowstone_intel and
SMS.f19_g16.IG.yellowstone_intel (note: I did not actually run these tests, I
simply set them up).

Test baseline: N/A
Test namelist changes: N/A
Test status: N/A

Fixes: None

User interface changes?: No

Code review: None yet
