### PR TITLE
Fixed incorrect cleaning of case.* scripts in create_clone

### DIFF
--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -141,15 +141,16 @@ $sysmod = "cp -rp $cloneroot/* $caseroot";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 
 # Remove unwanted files from $cloneroot
-# Note - script files are named using the first 12-15 chars of $clone and we want to remove those as well
+# Note - script files used to be named using the first 12-15 chars of $clone, but are now named case.$SCRIPT
+# Need to remove those. 
 $sysmod = "rm -rf $caseroot/Buildconf/*"  ; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -rf $caseroot/CaseDocs/*"   ; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -rf $caseroot/LockedFiles/*"; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -rf $caseroot/logs/*"       ; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -rf $caseroot/timing/*"     ; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -rf $caseroot/TestStatus*"  ; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
-my $clonesubname = substr($clone,0,12);
-$sysmod = "rm -f $caseroot/$clonesubname*"; 
+# Remove case.* scripts
+$sysmod = "rm -f $caseroot/case.*"; 
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -f $caseroot/*~";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
@@ -198,17 +199,23 @@ $sysmod = "cp $caseroot/env_case.xml $caseroot/LockedFiles/env_case.xml.locked";
 system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 print "Locking file $caseroot/env_case.xml \n";
 
-# Create $caseroot/$case.build
+# Create $caseroot/case.setup
+$sysmod = "cp $cimeroot/scripts/Tools/case.setup  $caseroot/case.setup";
+system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
+$sysmod = "chmod 755 $caseroot/case.setup";
+system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
+
+# Create $caseroot/case.build
 $sysmod = "cp $cimeroot/scripts/Tools/case.build  $caseroot/case.build";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "chmod 755 $caseroot/case.build";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 
-# Create $case.clean_build
+# Create case.clean_build
 $sysmod = "cp $cimeroot/scripts/Tools/clean_build $caseroot/case.clean_build"; 
 system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
     
-# Create $case.submit
+# Create case.submit
 $sysmod = "cp  $cimeroot/scripts/Tools/case.submit $caseroot/case.submit"; 
 system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 

--- a/tools/statistical_ensemble_test/ensemble.sh
+++ b/tools/statistical_ensemble_test/ensemble.sh
@@ -238,7 +238,7 @@ create_cases ()
     echo "running ./xmlchange BUILD_COMPLETE=\"TRUE\""
     ./xmlchange BUILD_COMPLETE="TRUE"
     echo "running case.setup"
-    `./case.setup`
+    ./case.setup
 
     # For validations, subsequent cloned cases will have the pertlim from the
     # parent case. We neet to remove the original case's pertlim before we set

--- a/tools/statistical_ensemble_test/single_run.sh
+++ b/tools/statistical_ensemble_test/single_run.sh
@@ -368,7 +368,7 @@ fi
 
 # Unset LS_COLORS before configure runs
 LS_COLORS=
-`./case.setup` || { echo "Error running case_setup, probably a bad NP value"; exit 1; }
+./case.setup || { echo "Error running case_setup, probably a bad NP value"; exit 1; }
 chmod u+w user_nl_*
 if [ $LENS -eq 1 ]; then
   cp -f $ThisDir/user_nl_cam_LENS ./user_nl_cam


### PR DESCRIPTION
create_clone was incorrectly trying to remove $CASE.\* scripts
instead of case.\* scripts.  Fixed incorrect usage of
backticks in case.setup for ensemble scripts

Test suite: Manual verification
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes: #293

Code review: n/a
