### PR TITLE
Ompenv update

### DIFF
--- a/cime_config/cesm/allactive/config_pes.xml
+++ b/cime_config/cesm/allactive/config_pes.xml
@@ -76,6 +76,43 @@
       </pes>
     </mach>
   </grid>
+  <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1">
+    <mach name="corip1">
+      <pes pesize="any" compset="any">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-16</ntasks_atm> 
+	  <ntasks_lnd>-9</ntasks_lnd>           
+	  <ntasks_rof>-9</ntasks_rof> 
+	  <ntasks_ice>-7</ntasks_ice> 
+	  <ntasks_ocn>-1</ntasks_ocn> 
+	  <ntasks_glc>-1</ntasks_glc> 
+	  <ntasks_wav>-1</ntasks_wav> 
+	  <ntasks_cpl>-16</ntasks_cpl> 
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>8</nthrds_atm>                   
+	  <nthrds_lnd>8</nthrds_lnd> 
+	  <nthrds_rof>8</nthrds_rof> 
+	  <nthrds_ice>8</nthrds_ice> 
+	  <nthrds_ocn>8</nthrds_ocn> 
+	  <nthrds_glc>8</nthrds_glc> 
+	  <nthrds_wav>8</nthrds_wav> 
+	  <nthrds_cpl>8</nthrds_cpl> 
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm> 
+	  <rootpe_lnd>0</rootpe_lnd> 
+	  <rootpe_rof>0</rootpe_rof> 
+	  <rootpe_ice>-9</rootpe_ice>    
+	  <rootpe_ocn>-16</rootpe_ocn>   
+	  <rootpe_glc>0</rootpe_glc> 
+	  <rootpe_wav>0</rootpe_wav> 
+	  <rootpe_cpl>0</rootpe_cpl>                         
+	</rootpe>
+      </pes>
+    </mach>
+  </grid>
   <grid name="a%T31.+l%T31.+oi%gx3">
     <mach name="yellowstone">
       <pes pesize="any" compset="any">
@@ -1003,10 +1040,10 @@
 	<comment>none</comment>
 	<ntasks>
 	  <ntasks_atm>-8</ntasks_atm> 
-	  <ntasks_lnd>-8</ntasks_lnd>           
-	  <ntasks_rof>-8</ntasks_rof> 
-	  <ntasks_ice>-8</ntasks_ice> 
-	  <ntasks_ocn>-8</ntasks_ocn> 
+	  <ntasks_lnd>-4</ntasks_lnd>           
+	  <ntasks_rof>-4</ntasks_rof> 
+	  <ntasks_ice>-4</ntasks_ice> 
+	  <ntasks_ocn>-1</ntasks_ocn> 
 	  <ntasks_glc>-8</ntasks_glc> 
 	  <ntasks_wav>-8</ntasks_wav> 
 	  <ntasks_cpl>-8</ntasks_cpl> 
@@ -1025,8 +1062,45 @@
 	  <rootpe_atm>0</rootpe_atm> 
 	  <rootpe_lnd>0</rootpe_lnd> 
 	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
+	  <rootpe_ice>-4</rootpe_ice>    
+	  <rootpe_ocn>-8</rootpe_ocn>   
+	  <rootpe_glc>0</rootpe_glc> 
+	  <rootpe_wav>0</rootpe_wav> 
+	  <rootpe_cpl>0</rootpe_cpl>                         
+	</rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
+    <mach name='corip1'>
+      <pes pesize="any" compset="any">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-16</ntasks_atm> 
+	  <ntasks_lnd>-9</ntasks_lnd>           
+	  <ntasks_rof>-9</ntasks_rof> 
+	  <ntasks_ice>-7</ntasks_ice> 
+	  <ntasks_ocn>-1</ntasks_ocn> 
+	  <ntasks_glc>-1</ntasks_glc> 
+	  <ntasks_wav>-1</ntasks_wav> 
+	  <ntasks_cpl>-16</ntasks_cpl> 
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>8</nthrds_atm>                   
+	  <nthrds_lnd>8</nthrds_lnd> 
+	  <nthrds_rof>8</nthrds_rof> 
+	  <nthrds_ice>8</nthrds_ice> 
+	  <nthrds_ocn>8</nthrds_ocn> 
+	  <nthrds_glc>8</nthrds_glc> 
+	  <nthrds_wav>8</nthrds_wav> 
+	  <nthrds_cpl>8</nthrds_cpl> 
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm> 
+	  <rootpe_lnd>0</rootpe_lnd> 
+	  <rootpe_rof>0</rootpe_rof> 
+	  <rootpe_ice>-9</rootpe_ice>    
+	  <rootpe_ocn>-16</rootpe_ocn>   
 	  <rootpe_glc>0</rootpe_glc> 
 	  <rootpe_wav>0</rootpe_wav> 
 	  <rootpe_cpl>0</rootpe_cpl>                         

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -338,6 +338,9 @@
         <command name="load">CESM-ENV</command>
       </modules>
     </module_system>
+    <environment_variables>
+      <env name="OMP_STACKSIZE">64M</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="brutus">
@@ -412,13 +415,128 @@
 	<command name="load">netcdf/4.0.1</command>
       </modules>
     </module_system>
+    <environment_variables>
+      <env name="OMP_STACKSIZE">64M</env>
+    </environment_variables>
+  </machine>
+
+  <machine MACH="corip1">
+    <DESC>NERSC XC30 Haswell, os is CNL, 24 pes/node, batch system is Slurm</DESC>
+    <COMPILERS>intel,gnu,cray</COMPILERS>
+    <MPILIBS>mpt,mpi-serial</MPILIBS>
+    <CESMSCRATCHROOT>$ENV{SCRATCH}</CESMSCRATCHROOT>
+    <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
+    <DIN_LOC_ROOT>/project/projectdirs/ccsm1/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/ccsm1/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CESMSCRATCHROOT/archive/$CASE</DOUT_S_ROOT>
+    <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
+    <CCSM_BASELINE>/project/projectdirs/ccsm1/ccsm_baselines</CCSM_BASELINE>
+    <CCSM_CPRNC>/project/projectdirs/ccsm1/tools/cprnc.corip1/cprnc</CCSM_CPRNC>
+    <OS>CNL</OS>
+    <BATCHQUERY>squeue</BATCHQUERY>
+    <BATCHSUBMIT>sbatch</BATCHSUBMIT>
+    <BATCHREDIRECT></BATCHREDIRECT>
+    <SUPPORTED_BY>cseg</SUPPORTED_BY>
+    <GMAKE_J>8</GMAKE_J>
+    <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
+    <PES_PER_NODE>32</PES_PER_NODE>
+    <batch_system type="slurm" version="x.y">
+      <queues>
+        <queue walltimemax="00:06:00" jobmin="1" jobmax="16384" >regular</queue>
+        <queue walltimemax="00:04:00" jobmin="16385" jobmax="32768" >regular</queue>
+        <queue walltimemax="00:02:00" jobmin="32769" jobmax="52096" >regular</queue>
+	<queue walltimemax="00:30:00" jobmin="1" jobmax="4096" default="true">debug</queue>
+      </queues>
+      <walltimes>
+	<walltime default="true">00:30:00</walltime>
+	<walltime ccsm_estcost="1">01:50:00</walltime>
+	<walltime ccsm_estcost="3">05:00:00</walltime>
+      </walltimes>
+    </batch_system>
+    <mpirun mpilib="default">
+      <executable>srun</executable>
+      <arguments>
+	<arg name="label"> --label</arg>
+	<arg name="num_tasks" > -n {{ num_tasks }}</arg>
+
+	<arg name="thread_count" > -c {{ thread_count }}</arg>
+
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="perl">/opt/modules/default/init/perl.pm</init_path>
+      <init_path lang="sh">/opt/modules/default/init/sh</init_path>
+      <init_path lang="csh">/opt/modules/default/init/csh</init_path>
+      <cmd_path lang="perl">/opt/modules/default/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+	<command name="rm">PrgEnv-intel</command>
+	<command name="rm">PrgEnv-cray</command>
+	<command name="rm">PrgEnv-gnu</command>
+	<command name="rm">intel</command>
+	<command name="rm">cce</command>
+	<command name="rm">cray-parallel-netcdf</command>
+	<command name="rm">cray-parallel-hdf5</command>
+	<command name="rm">pmi</command>
+	<command name="rm">cray-libsci</command>
+	<command name="rm">cray-mpich2</command>
+	<command name="rm">cray-mpich</command>
+	<command name="rm">cray-netcdf</command>
+	<command name="rm">cray-hdf5</command>
+	<command name="rm">cray-netcdf-hdf5parallel</command>
+	<command name="rm">craype-sandybridge</command>
+	<command name="rm">craype-ivybridge</command>
+	<command name="rm">craype</command>
+      </modules>
+      
+      <modules compiler="intel">
+	<command name="load">PrgEnv-intel</command>
+	<command name="switch">intel intel/2016.0.109</command>
+	<command name="rm">cray-libsci</command>
+      </modules>
+      <modules compiler="cray">
+	<command name="load">PrgEnv-cray</command>
+	<command name="switch">cce cce/8.4.0</command>
+      </modules>
+      <modules compiler="gnu">
+	<command name="load">PrgEnv-gnu</command>
+	<command name="switch">gcc gcc/5.1.0</command>
+      </modules>
+      <modules>
+	<command name="load">papi/5.4.1.2</command>
+	<command name="swap">craype craype/2.4.2</command>
+      </modules>
+      <modules compiler="!intel">
+	<command name="switch">cray-libsci/13.2.0</command>
+      </modules>
+      <modules>
+	<command name="load">cray-mpich/7.2.5</command>
+      </modules>
+      <modules mpilib="mpi-serial">
+	<command name="load">cray-hdf5/1.8.14</command>
+	<command name="load">cray-netcdf/4.3.3.1</command>
+      </modules>
+      <modules mpilib="!mpi-serial">
+	<command name="load">cray-netcdf-hdf5parallel/4.3.3.1</command>
+	<command name="load">cray-hdf5-parallel/1.8.14</command>
+	<command name="load">cray-parallel-netcdf/1.6.1</command>
+      </modules>
+      <modules>
+	<command name="load">cmake/3.3.2</command>
+      </modules>
+    </module_system>
+    <environment_variables>
+      <env name="OMP_STACKSIZE">256M</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="eastwind">
     <DESC>PNL IBM Xeon cluster, os is Linux (pgi), batch system is SLURM</DESC>
     <OS>LINUX</OS>
     <COMPILERS>pgi,intel</COMPILERS>
-    <MPILIBS>mpich</MPILIBS>
+    <MPILIBS>mvapich2,mvapich</MPILIBS>
     <RUNDIR>/lustre/$USER/$CASE/run</RUNDIR>
     <EXEROOT>/lustre/$USER/$CASE/bld</EXEROOT>
     <CESMSCRATCHROOT>/lustre/$USER</CESMSCRATCHROOT>
@@ -436,9 +554,9 @@
     <MAX_TASKS_PER_NODE>12</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>12</PES_PER_NODE>
     <batch_system type="slurm" version="x.y">
-      <queues>
+    <queues>
 	<queue jobmin="1" jobmax="9999" default="true">batch</queue>
-      </queues>
+    </queues> 
       <walltimes>
 	<walltime default="true">0:59:00</walltime>
       </walltimes>
@@ -466,17 +584,21 @@
       <init_path lang="perl">/etc/profile.d/modules.perl</init_path>
       <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
       <init_path lang="csh">/etc/profile.d/modules.csh</init_path>
-      <!-- This is a guess!! -->
-      <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="perl">/share/apps/modules/Modules/3.2.7/bin/modulecmd perl</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
 	<command name="purge"/> 
-	<command name="load">pgi/11.3</command>
+        <command name="load">perl/5.20.7</command>
+        <command name="load">cmake/3.0.0</command>
+        <command name="load">pgi/15.5</command>
 	<command name="load">mpi/mvapich2/1.5.1p1/pgi11.3</command>
 	<command name="load">netcdf/4.1.2/pgi</command>
       </modules>
     </module_system>
+    <environment_variables>
+      <env name="OMP_STACKSIZE">64M</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="edison">
@@ -558,11 +680,11 @@
 	<command name="rm">cray-libsci</command>
 	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/edison</command>
       </modules>
-      <modules compiler="intel" debug="true">
-	<command name="load">esmf/6.2.0-defio-mpi-g</command>
+      <modules compiler="intel" mpilib="!mpi-serial" >
+	<command name="load">esmf/6.3.0rp1-defio-intel15.0-mpi-0</command>
       </modules>
-      <modules compiler="intel" debug="false">
-	<command name="load">esmf/6.2.0-defio-mpi-O</command>
+      <modules compiler="intel" mpilib="mpi-serial" >
+        <command name="load">esmf/6.3.0rp1-defio-intel15.0-mpiuni-0</command>
       </modules>
       <modules compiler="cray">
 	<command name="load">PrgEnv-cray</command>
@@ -598,6 +720,11 @@
 	<command name="load">cmake/3.0.0</command>
       </modules>
     </module_system>
+
+    <environment_variables>
+      <env name="OMP_STACKSIZE">64M</env>
+    </environment_variables>
+
   </machine>
 
   <machine MACH="erebus">
@@ -668,6 +795,9 @@
 	<command name="load">pnetcdf/1.3.0</command>
       </modules>
     </module_system>
+    <environment_variables>
+      <env name="OMP_STACKSIZE">64M</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="eos">
@@ -768,6 +898,7 @@
     <environment_variables>
       <env name="MPICH_ENV_DISPLAY">1</env>
       <env name="MPICH_VERSION_DISPLAY">1</env>
+      <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
   </machine>
 
@@ -978,6 +1109,7 @@
     </module_system>
     <environment_variables>
       <env name="NETCDF">/usr/local/tools/netcdf-pgi-4.1.3/</env>
+      <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
   </machine>
 
@@ -1043,6 +1175,7 @@
     <environment_variables>
       <env name="MPI_TYPE_MAX">10000</env>
       <env name="OMP_DYNAMIC">FALSE</env>
+      <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
   </machine>
 
@@ -1101,6 +1234,9 @@
 	<command name="load">netcdf/4.1.3</command>
       </modules>
     </module_system>
+    <environment_variables>
+      <env name="OMP_STACKSIZE">64M</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="pleiades-has">
@@ -1163,6 +1299,7 @@
       <env name="MPI_TYPE_MAX">100000</env>
       <env name="KMP_AFFINITY">noverbose,disabled</env>
       <env name="KMP_SCHEDULE">static,balanced</env>
+      <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
   </machine>
 
@@ -1226,6 +1363,7 @@
       <env name="MPI_TYPE_MAX">100000</env>
       <env name="KMP_AFFINITY">noverbose,disabled</env>
       <env name="KMP_SCHEDULE">static,balanced</env>
+      <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
   </machine>
 
@@ -1289,6 +1427,7 @@
       <env name="MPI_TYPE_MAX">100000</env>
       <env name="KMP_AFFINITY">noverbose,disabled</env>
       <env name="KMP_SCHEDULE">static,balanced</env>
+      <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
   </machine>
 
@@ -1352,6 +1491,7 @@
       <env name="MPI_TYPE_MAX">100000</env>
       <env name="KMP_AFFINITY">noverbose,disabled</env>
       <env name="KMP_SCHEDULE">static,balanced</env>
+      <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
   </machine>
 
@@ -1403,6 +1543,7 @@
     </module_system>
     <environment_variables>
       <env name="NETCDF">/usr/local/tools/netcdf-pgi-4.1.3/</env>
+      <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
   </machine>
 
@@ -1515,6 +1656,8 @@
       <env name="MP_MPILIB">$MPILIB</env>
       <env name="MP_STDOUTMODE">unordered</env>
       <env name="MP_RC_USE_LMC">yes</env>
+    </environment_variables>
+    <environment_variables debug="true">
       <env name="MP_EAGER_LIMIT">0</env>
     </environment_variables>
   </machine>
@@ -1563,6 +1706,9 @@
       <cmd_path lang="csh"></cmd_path>
       <cmd_path lang="sh"></cmd_path>
     </module_system>
+    <environment_variables>
+      <env name="OMP_STACKSIZE">64M</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="constance">
@@ -1597,6 +1743,9 @@
 	<command name="load">intel/15.0.1</command>
       </modules>
     </module_system>
+    <environment_variables>
+      <env name="OMP_STACKSIZE">64M</env>
+    </environment_variables>
   </machine>
 
   <default_run_suffix>$config{'EXEROOT'}/cesm.exe >> cesm.log.$LID 2>&amp;1</default_run_suffix>


### PR DESCRIPTION
This sets the OMP_STACKSIZE for all machines 
Sets MP_EAGER_LIMIT 0 on yellowstone for debug only
Prints the env settings to stdout as they are set.  
Adds pe-layouts for corip1. 
