### PR TITLE
Ensemblefix

### DIFF
--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -80,12 +80,6 @@ if (@ARGV) {
 my $scriptdir = dirname(rel2abs($0));
 my $newcimeroot = abs_path("$scriptdir/..");
 my $newsrcroot = abs_path("$scriptdir/../..");
-my $warning = <<EOF;
-$banner
-Please be advised, it is NOT recommended to clone cases from different versions of CESM.
-$banner
-EOF
-print $warning;
 
 
 # Check for manditory case input if not just listing valid values
@@ -140,6 +134,15 @@ my $srcroot  = `./xmlquery SRCROOT -value`;
 my $machdir   = `./xmlquery MACHDIR  -value`;
 my $mach      = `./xmlquery MACH     -value`;
 my $origexeroot = `./xmlquery EXEROOT -value`;
+if($cimeroot ne $newcimeroot)
+{
+    my $warning = <<EOF;
+$banner
+Please be advised, it is NOT recommended to clone cases from different versions of CESM.
+$banner
+EOF
+    print $warning;
+}
 
 # Update paths that Perl searches for modules
 my @dirs = ("$cimeroot/utils/perl5lib");

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -17,7 +17,10 @@ use IO::Handle;
 use Data::Dumper;
 use File::Find;
 use File::Basename;
+use File::Spec::Functions qw(rel2abs);
 
+my @argstash = @ARGV;
+my $banner = '=' x 80;
 #-----------------------------------------------------------------------------------------------
 # Setting autoflush (an IO::Handle method) on STDOUT helps in debugging.  It forces the test
 # descriptions to be printed to STDOUT before the error messages start.
@@ -61,6 +64,7 @@ GetOptions(
     "clone=s"                   => \$opts{'clone'},
     "mach_dir=s"                => \$opts{'mach_dir'},
     "project=s"                 => \$opts{'project'},
+    "keepexe"                   => \$opts{'keepexe'},
     "s|silent"                  => \$opts{'silent'},
     "v|verbose"                 => \$opts{'verbose'},
 )  or usage();
@@ -73,7 +77,9 @@ if (@ARGV) {
     print "ERROR: unrecognized arguments: @ARGV\n";
     usage();
 }
-my $banner = '=' x 80;
+my $scriptdir = dirname(rel2abs($0));
+my $newcimeroot = abs_path("$scriptdir/..");
+my $newsrcroot = abs_path("$scriptdir/../..");
 my $warning = <<EOF;
 $banner
 Please be advised, it is NOT recommended to clone cases from different versions of CESM.
@@ -133,6 +139,7 @@ my $cimeroot  = `./xmlquery CIMEROOT -value`;
 my $srcroot  = `./xmlquery SRCROOT -value`;
 my $machdir   = `./xmlquery MACHDIR  -value`;
 my $mach      = `./xmlquery MACH     -value`;
+my $origexeroot = `./xmlquery EXEROOT -value`;
 
 # Update paths that Perl searches for modules
 my @dirs = ("$cimeroot/utils/perl5lib");
@@ -167,11 +174,30 @@ $sysmod = "rm -f $caseroot/*~";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 
 # Need to copy back in the CaseDocs/README
-$sysmod = "cp -rp $cloneroot/CaseDocs/README $caseroot/CaseDocs/."; 
+$sysmod = "cp -rp $cloneroot/README.case $caseroot/CaseDocs/README.case"; 
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
+
+# append create_clone and args to cloned case README.case
+open (my $RCASE, ">>", "$caseroot/README.case") or die "could not open $caseroot/README.case: $!";
+print $RCASE "$0 ";
+map {print $RCASE "$_ "} @argstash;
+print $RCASE "\n";
+close $RCASE;
+
+#append create_clone and args to cloned case CaseStatus
+open (my $CSTATUS, ">>", "$caseroot/CaseStatus") or die "could not open $caseroot/CaseStatus: $!";
+print $CSTATUS "$0 ";
+map {print $CSTATUS "$_ "} @argstash;
+print $CSTATUS "\n";
+close $CSTATUS;
 
 # Change directory to be $caseroot
 chdir $caseroot;
+#-----------------------------------------------------------------------------------------------
+## Now run a find and replace on all the files found in the new case, substitute the fo
+##-----------------------------------------------------------------------------------------------
+my @casesearch = ($caseroot);
+find(\&substitute, @casesearch);
 
 # Obtain variables needed below
 my $username  = "$ENV{'USER'}"; 
@@ -185,6 +211,13 @@ $sysmod = "./xmlchange CONTINUE_RUN=FALSE"		; system($sysmod) == 0 or die "ERROR
 $sysmod = "./xmlchange RESUBMIT=0"			; system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 if ($opts{'mach_dir'}) {
     $sysmod = "./xmlchange MACHIDR=$opts{'mach_dir'}"   ; system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
+}
+if($opts{'keepexe'})
+{
+    $sysmod = "./xmlchange EXEROOT=$origexeroot"; system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
+    $sysmod = "./xmlchange BUILD_COMPLETE=TRUE"; system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
+    #$sysmod = "mkdir $caseroot/Buildconf"; system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
+    $sysmod = "cp -Rp $cloneroot/Buildconf/* $caseroot/Buildconf/"; system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 }
 
 # --- Set project id 
@@ -230,17 +263,6 @@ system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 $sysmod = "cp  $cimeroot/scripts/Tools/case.submit $caseroot/case.submit"; 
 system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 
-#-----------------------------------------------------------------------------------------------
-# Now run a find and replace on all the files found in the new case, substitute the fo
-#-----------------------------------------------------------------------------------------------
-my $scriptdir = dirname(__FILE__);
-print "script dir: $scriptdir\n";
-my $newcimeroot = abs_path("$scriptdir/../..");
-my $newsrcroot = abs_path("$scriptdir/../../..");
-my @casesearch = ($caseroot);
-find(\&substitute, @casesearch);
-
-
 
 #-----------------------------------------------------------------------------------------------
 # Create batch script
@@ -261,8 +283,11 @@ sub substitute()
         my @matches = grep { m/($cimeroot|$srcroot)/ } @lines;
         if(@matches)
         {
+            #print Dumper \@matches;
             for my $i(0 .. $#lines)
             {
+                #print "line before replace\n";
+                #print $lines[$i] . "\n";
                 if($lines[$i] =~ /$cimeroot/)
                 {
                     $lines[$i] =~ s/$cimeroot/$newcimeroot/g;
@@ -271,7 +296,6 @@ sub substitute()
                 {
                     $lines[$i] =~ s/$srcroot/$newsrcroot/g;
                 }
-                #print "new line: $lines[$i]\n";
             }
             open (my $NEWF, ">", $filetosearch) or die "could not open $filetosearch for writing, $! $?";
             map { print $NEWF "$_\n"} @lines;

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -15,6 +15,8 @@ use Getopt::Long;
 use IO::File;
 use IO::Handle;
 use Data::Dumper;
+use File::Find;
+use File::Basename;
 
 #-----------------------------------------------------------------------------------------------
 # Setting autoflush (an IO::Handle method) on STDOUT helps in debugging.  It forces the test
@@ -120,6 +122,7 @@ my $eol = "\n";
 # Obtain necessary variables from $cloneroot
 chdir ("$cloneroot");
 my $cimeroot  = `./xmlquery CIMEROOT -value`;
+my $srcroot  = `./xmlquery SRCROOT -value`;
 my $machdir   = `./xmlquery MACHDIR  -value`;
 my $mach      = `./xmlquery MACH     -value`;
 
@@ -219,6 +222,16 @@ system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 $sysmod = "cp  $cimeroot/scripts/Tools/case.submit $caseroot/case.submit"; 
 system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 
+#-----------------------------------------------------------------------------------------------
+# Now run a find and replace on all the files found in the new case, substitute the fo
+#-----------------------------------------------------------------------------------------------
+my $scriptdir = dirname(__FILE__);
+print "script dir: $scriptdir\n";
+my $newcimeroot = abs_path("$scriptdir/../..");
+my $newsrcroot = abs_path("$scriptdir/../../..");
+my @casesearch = ($caseroot);
+find(\&substitute, @casesearch);
+
 
 
 #-----------------------------------------------------------------------------------------------
@@ -226,6 +239,39 @@ system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 $sysmod = "./case.setup"; 
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 
+
+sub substitute()
+{
+    my $filetosearch = $File::Find::name;
+    if(-f $filetosearch && ! -d $filetosearch)
+    {
+        #print "file to search: $filetosearch\n";
+        open(my $F, "<", $filetosearch) or die "could not open $filetosearch for reading, $!, $?";
+        my @lines =  <$F>;
+        chomp @lines;
+        close $F;
+        my @matches = grep { m/($cimeroot|$srcroot)/ } @lines;
+        if(@matches)
+        {
+            for my $i(0 .. $#lines)
+            {
+                if($lines[$i] =~ /$cimeroot/)
+                {
+                    $lines[$i] =~ s/$cimeroot/$newcimeroot/g;
+                }
+                if($lines[$i] =~ /$srcroot/)
+                {
+                    $lines[$i] =~ s/$srcroot/$newsrcroot/g;
+                }
+                #print "new line: $lines[$i]\n";
+            }
+            open (my $NEWF, ">", $filetosearch) or die "could not open $filetosearch for writing, $! $?";
+            map { print $NEWF "$_\n"} @lines;
+            close $NEWF;
+        }
+    }
+
+}
 # --- Print output ---
 my $compset = `./xmlquery COMPSET -value`;
 print "Successfully created new case\n   $caseroot\nfrom clone case\n   $cloneroot\n";

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -73,6 +73,14 @@ if (@ARGV) {
     print "ERROR: unrecognized arguments: @ARGV\n";
     usage();
 }
+my $banner = '=' x 80;
+my $warning = <<EOF;
+$banner
+Please be advised, it is NOT recommended to clone cases from different versions of CESM.
+$banner
+EOF
+print $warning;
+
 
 # Check for manditory case input if not just listing valid values
 my $case;

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -141,15 +141,16 @@ $sysmod = "cp -rp $cloneroot/* $caseroot";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 
 # Remove unwanted files from $cloneroot
-# Note - script files are named using the first 12-15 chars of $clone and we want to remove those as well
+# Note - script files used to be named using the first 12-15 chars of $clone, but are now named case.$SCRIPT
+# Need to remove those. 
 $sysmod = "rm -rf $caseroot/Buildconf/*"  ; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -rf $caseroot/CaseDocs/*"   ; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -rf $caseroot/LockedFiles/*"; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -rf $caseroot/logs/*"       ; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -rf $caseroot/timing/*"     ; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -rf $caseroot/TestStatus*"  ; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
-my $clonesubname = substr($clone,0,12);
-$sysmod = "rm -f $caseroot/$clonesubname*"; 
+# Remove case.* scripts
+$sysmod = "rm -f $caseroot/case.*"; 
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -f $caseroot/*~";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
@@ -198,17 +199,23 @@ $sysmod = "cp $caseroot/env_case.xml $caseroot/LockedFiles/env_case.xml.locked";
 system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 print "Locking file $caseroot/env_case.xml \n";
 
-# Create $caseroot/$case.build
+# Create $caseroot/case.setup
+$sysmod = "cp $cimeroot/scripts/Tools/case.setup  $caseroot/case.setup";
+system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
+$sysmod = "chmod 755 $caseroot/case.setup";
+system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
+
+# Create $caseroot/case.build
 $sysmod = "cp $cimeroot/scripts/Tools/case.build  $caseroot/case.build";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "chmod 755 $caseroot/case.build";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 
-# Create $case.clean_build
+# Create case.clean_build
 $sysmod = "cp $cimeroot/scripts/Tools/clean_build $caseroot/case.clean_build"; 
 system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
     
-# Create $case.submit
+# Create case.submit
 $sysmod = "cp  $cimeroot/scripts/Tools/case.submit $caseroot/case.submit"; 
 system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 

--- a/tools/statistical_ensemble_test/ensemble.sh
+++ b/tools/statistical_ensemble_test/ensemble.sh
@@ -238,7 +238,7 @@ create_cases ()
     echo "running ./xmlchange BUILD_COMPLETE=\"TRUE\""
     ./xmlchange BUILD_COMPLETE="TRUE"
     echo "running case.setup"
-    `./case.setup`
+    ./case.setup
 
     # For validations, subsequent cloned cases will have the pertlim from the
     # parent case. We neet to remove the original case's pertlim before we set

--- a/tools/statistical_ensemble_test/ensemble.sh
+++ b/tools/statistical_ensemble_test/ensemble.sh
@@ -215,7 +215,10 @@ create_cases ()
 
     # Create clone
     cd $SCRIPTS_ROOT
-    ./create_clone -case $CASE1 -clone $CASE # Copy $CASE to $CASE1
+    echo "=== SCRIPTS_ROOT ==="
+    echo $SCRIPTS_ROOT
+    #./create_clone -keepexe -case $CASE1 -clone $CASE # Copy $CASE to $CASE1
+    $SCRIPTS_ROOT/create_clone -keepexe -case $CASE1 -clone $CASE # Copy $CASE to $CASE1
 
     # Get value for EXEROOT from $CASE
     # Note return string is "EXEROOT = $EXEROOT"
@@ -233,10 +236,10 @@ create_cases ()
     else
       cd $CASE1
     fi
-	echo "running ./xmlchange EXEROOT=\"$EXEROOT\""
-    ./xmlchange EXEROOT="$EXEROOT"
-    echo "running ./xmlchange BUILD_COMPLETE=\"TRUE\""
-    ./xmlchange BUILD_COMPLETE="TRUE"
+	#echo "running ./xmlchange EXEROOT=\"$EXEROOT\""
+    #./xmlchange EXEROOT="$EXEROOT"
+    #echo "running ./xmlchange BUILD_COMPLETE=\"TRUE\""
+    #./xmlchange BUILD_COMPLETE="TRUE"
     echo "running case.setup"
     ./case.setup
 

--- a/tools/statistical_ensemble_test/single_run.sh
+++ b/tools/statistical_ensemble_test/single_run.sh
@@ -368,7 +368,7 @@ fi
 
 # Unset LS_COLORS before configure runs
 LS_COLORS=
-`./case.setup` || { echo "Error running case_setup, probably a bad NP value"; exit 1; }
+./case.setup || { echo "Error running case_setup, probably a bad NP value"; exit 1; }
 chmod u+w user_nl_*
 if [ $LENS -eq 1 ]; then
   cp -f $ThisDir/user_nl_cam_LENS ./user_nl_cam


### PR DESCRIPTION
```
create_clone now substitutes old cime/srcroot with new.

Fixed create_clone so that it substitutes the old cimeroot
and srcroot with the new directories in the cloned case.
Test suite: ERI, manual case clone
Test baseline: n/a
Test namelist changes: n/a
Test status: bit for bit

Fixes: #293

Code review: n/a
```
