### PR TITLE
Mlevy/introducing mcog

### DIFF
--- a/components/data_comps/dice/bld/namelist_files/namelist_definition_dice.xml
+++ b/components/data_comps/dice/bld/namelist_files/namelist_definition_dice.xml
@@ -257,7 +257,7 @@ default: .false.
 </entry>
 
 <entry id="flux_qacc0" 
-type="logical"  
+type="real"  
 category="dice"
 group="dice_nml" >
 initial water accumulation value
@@ -265,7 +265,7 @@ default: 0.
 </entry>
 
 <entry id="flux_qmin" 
-type="logical"  
+type="real"  
 category="dice"
 group="dice_nml" >
 bound on melt rate
@@ -273,7 +273,7 @@ default: -300.0e0
 </entry>
 
 <entry id="flux_swpf" 
-type="logical"  
+type="real"  
 category="dice"
 group="dice_nml" >
 short-wave penatration factor

--- a/components/data_comps/dice/dice_comp_mod.F90
+++ b/components/data_comps/dice/dice_comp_mod.F90
@@ -98,6 +98,9 @@ module dice_comp_mod
   integer(IN) :: kiFrac,kt,kavsdr,kanidr,kavsdf,kanidf,kswnet,kmelth,kmeltw
   integer(IN) :: ksen,klat,klwup,kevap,ktauxa,ktauya,ktref,kqref,kswpen,ktauxo,ktauyo,ksalt
 
+  ! optional per thickness category fields
+  integer(IN) :: kiFrac_01,kswpen_iFrac_01
+
   type(shr_strdata_type) :: SDICE
   type(mct_rearr) :: rearr
 !  type(mct_avect) :: avstrm   ! av of data from stream
@@ -459,6 +462,13 @@ subroutine dice_comp_init( EClock, cdata, x2i, i2x, NLFilename )
     ktauxo = mct_aVect_indexRA(i2x,'Fioi_taux')
     ktauyo = mct_aVect_indexRA(i2x,'Fioi_tauy')
     ksalt  = mct_aVect_indexRA(i2x,'Fioi_salt')
+
+    ! optional per thickness category fields
+
+    if (seq_flds_i2o_per_cat) then
+      kiFrac_01       = mct_aVect_indexRA(i2x,'Si_ifrac_01')
+      kswpen_iFrac_01 = mct_aVect_indexRA(i2x,'PFioi_swpen_ifrac_01')
+    end if
 
     call mct_aVect_init(x2i, rList=seq_flds_x2i_fields, lsize=lsize)
     call mct_aVect_zero(x2i)
@@ -839,6 +849,15 @@ subroutine dice_comp_run( EClock, cdata,  x2i, i2x)
 
 
    end select
+
+   ! optional per thickness category fields
+
+   if (seq_flds_i2o_per_cat) then
+      do n=1,lsize
+         i2x%rAttr(kiFrac_01,n)       = i2x%rAttr(kiFrac,n)
+         i2x%rAttr(kswpen_iFrac_01,n) = i2x%rAttr(kswpen,n) * i2x%rAttr(kiFrac,n)
+      end do
+   end if
 
    call t_stopf('dice_mode')
 

--- a/components/data_comps/dice/dice_comp_mod.F90
+++ b/components/data_comps/dice/dice_comp_mod.F90
@@ -28,7 +28,8 @@ module dice_comp_mod
   use seq_timemgr_mod
   use seq_comm_mct     , only: seq_comm_inst, seq_comm_name, seq_comm_suffix
   use seq_flds_mod     , only: seq_flds_i2x_fields, &
-                               seq_flds_x2i_fields
+                               seq_flds_x2i_fields, &
+                               seq_flds_i2o_per_cat
 !
 ! !PUBLIC TYPES:
   implicit none

--- a/driver_cpl/bld/build-namelist
+++ b/driver_cpl/bld/build-namelist
@@ -344,11 +344,18 @@ if ($CCSM_BGC eq 'CO2A') {
 my $glc_nec = "$xmlvars{'GLC_NEC'}";
 if ( ! defined $glc_nec ) {$glc_nec = 0;}
 
+my $ice_ncat = $xmlvars{'ICE_NCAT'};
+
+my $seq_flds_i2o_per_cat = ".false.";
+if ($xmlvars{'CPL_I2O_PER_CAT'} eq 'TRUE') { $seq_flds_i2o_per_cat = ".true." }
+
 add_default($nl, 'flds_co2a',    'val'=>"$flds_co2a");
 add_default($nl, 'flds_co2b',    'val'=>"$flds_co2b");
 add_default($nl, 'flds_co2c',    'val'=>"$flds_co2c");
 add_default($nl, 'flds_co2_dmsa','val'=>"$flds_co2_dmsa");
 add_default($nl, 'glc_nec',      'val'=>"$glc_nec");
+add_default($nl, 'ice_ncat',     'val'=>"$ice_ncat");
+add_default($nl, 'seq_flds_i2o_per_cat', 'val'=>"$seq_flds_i2o_per_cat");
     
 #############################################
 # namelist group: seq_cplflds_userspec      #

--- a/driver_cpl/bld/build-namelist
+++ b/driver_cpl/bld/build-namelist
@@ -354,8 +354,8 @@ add_default($nl, 'flds_co2b',    'val'=>"$flds_co2b");
 add_default($nl, 'flds_co2c',    'val'=>"$flds_co2c");
 add_default($nl, 'flds_co2_dmsa','val'=>"$flds_co2_dmsa");
 add_default($nl, 'glc_nec',      'val'=>"$glc_nec");
-add_default($nl, 'ice_ncat',     'val'=>"$ice_ncat");
-add_default($nl, 'seq_flds_i2o_per_cat', 'val'=>"$seq_flds_i2o_per_cat");
+add_default($nl, 'ice_ncat',     'val'=>"$ice_ncat", 'xml'=>'ICE_NCAT');
+add_default($nl, 'seq_flds_i2o_per_cat', 'val'=>"$seq_flds_i2o_per_cat", 'xml'=>'CPL_I2O_PER_CAT');
     
 #############################################
 # namelist group: seq_cplflds_userspec      #

--- a/driver_cpl/bld/namelist_files/namelist_definition_drv.xml
+++ b/driver_cpl/bld/namelist_files/namelist_definition_drv.xml
@@ -115,6 +115,23 @@ Number of cism elevation classes.
 Set by the xml variable GLC_NEC in env_run.xml
 </entry>
 
+<entry
+id="ice_ncat"
+type="integer"
+category="seq_flds"
+group="seq_cplflds_inparm" >
+Number of sea ice thickness categories. 
+Set by the xml variable ICE_NCAT in env_build.xml
+</entry>
+
+<entry
+id="seq_flds_i2o_per_cat"
+type="logical"
+category="seq_flds"
+group="seq_cplflds_inparm" >
+.true. if select per ice thickness category fields are passed to the ocean.
+Set by the xml variable CPL_I2O_PER_CAT in env_run.xml
+</entry>
 
 <!-- =========================== -->
 <!-- -group seq_cplflds_custom   -->

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -1062,6 +1062,7 @@
     <type>integer</type>
     <default_value>1</default_value>
     <group>build_grid</group>
+    <file>env_build.xml</file>
     <desc>number of ice thickness categories - DO NOT EDIT (set by CICE configure)</desc>
   </entry>
 
@@ -2792,6 +2793,7 @@
     <valid_values>TRUE,FALSE</valid_values>  
     <default_value>FALSE</default_value> 
     <group>run_coupling</group>
+    <file>env_run.xml</file>
     <desc>determine if per ice thickness category fields are passed from ice to ocean - DO NOT EDIT (set by POP build-namelist)</desc>
   </entry>
 

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -1058,6 +1058,13 @@
     <desc>number of ice cells in j direction - DO NOT EDIT (for experts only)</desc>
   </entry>
 
+  <entry id="ICE_NCAT"> 
+    <type>integer</type>
+    <default_value>1</default_value>
+    <group>build_grid</group>
+    <desc>number of ice thickness categories - DO NOT EDIT (set by CICE configure)</desc>
+  </entry>
+
   <entry id="ROF_GRID">
     <type>char</type>
     <default_value>UNSET</default_value>
@@ -2778,6 +2785,14 @@
       cpl_seq_option flags take it's place.
       TIGHT coupling makes no sense with the OPTION5 and OPTION6 flags.
     </desc>
+  </entry>
+
+  <entry id="CPL_I2O_PER_CAT">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>  
+    <default_value>FALSE</default_value> 
+    <group>run_coupling</group>
+    <desc>determine if per ice thickness category fields are passed from ice to ocean - DO NOT EDIT (set by POP build-namelist)</desc>
   </entry>
 
   <entry id="CCSM_BGC"> 

--- a/driver_cpl/driver/prep_ocn_mod.F90
+++ b/driver_cpl/driver/prep_ocn_mod.F90
@@ -536,6 +536,9 @@ contains
     integer, save :: index_x2o_Faxa_prec  
     integer, save :: index_x2o_Foxx_rofl
     integer, save :: index_x2o_Foxx_rofi
+    integer, save :: index_x2o_Sf_afrac
+    integer, save :: index_x2o_Sf_afracr
+    integer, save :: index_x2o_Foxx_swnet_afracr
     logical :: iamroot  
     logical, save, pointer :: amerge(:),imerge(:),xmerge(:)
     integer, save, pointer :: aindx(:), iindx(:), oindx(:), xindx(:)
@@ -584,6 +587,12 @@ contains
        index_x2o_Faxa_prec      = mct_aVect_indexRA(x2o_o,'Faxa_prec') 
        index_x2o_Foxx_rofl      = mct_aVect_indexRA(x2o_o,'Foxx_rofl') 
        index_x2o_Foxx_rofi      = mct_aVect_indexRA(x2o_o,'Foxx_rofi') 
+
+       if (seq_flds_i2o_per_cat) then
+          index_x2o_Sf_afrac          = mct_aVect_indexRA(x2o_o,'Sf_afrac')
+          index_x2o_Sf_afracr         = mct_aVect_indexRA(x2o_o,'Sf_afracr')
+          index_x2o_Foxx_swnet_afracr = mct_aVect_indexRA(x2o_o,'Foxx_swnet_afracr')
+       endif
 
        ! Compute all other quantities based on standardized naming convention (see below)
        ! Only ocn field states that have the name-prefix Sx_ will be merged
@@ -782,6 +791,13 @@ contains
           'a2x%Faxa_swndr*(1.0-xao%So_anidr) + '// &
           'a2x%Faxa_swndf*(1.0-xao%So_anidf)) + '// &
           'ifrac*i2x%Fioi_swpen'
+       if (seq_flds_i2o_per_cat) then
+          mrgstr(index_x2o_Foxx_swnet_afracr) = trim(mrgstr(index_x2o_Foxx_swnet_afracr))//' = '// &
+               'afracr*(a2x%Faxa_swvdr*(1.0-xao%So_avsdr) + '// &
+               'a2x%Faxa_swvdf*(1.0-xao%So_avsdf) + '// &
+               'a2x%Faxa_swndr*(1.0-xao%So_anidr) + '// &
+               'a2x%Faxa_swndf*(1.0-xao%So_anidf))'
+       end if
        mrgstr(index_x2o_Faxa_snow) = trim(mrgstr(index_x2o_Faxa_snow))//' = '// &
           'afrac*(a2x%Faxa_snowc + a2x%Faxa_snowl)*flux_epbalfact'
        mrgstr(index_x2o_Faxa_rain) = trim(mrgstr(index_x2o_Faxa_rain))//' = '// &
@@ -830,6 +846,12 @@ contains
                  + a2x_o%rAttr(index_a2x_Faxa_swndf,n) * (1.0_R8 - anidf)
        x2o_o%rAttr(index_x2o_Foxx_swnet,n) = (fswabsv + fswabsi)                 * afracr + &
                                              i2x_o%rAttr(index_i2x_Fioi_swpen,n) * ifrac
+
+       if (seq_flds_i2o_per_cat) then
+          x2o_o%rAttr(index_x2o_Sf_afrac,n)          = afrac
+          x2o_o%rAttr(index_x2o_Sf_afracr,n)         = afracr
+          x2o_o%rAttr(index_x2o_Foxx_swnet_afracr,n) = (fswabsv + fswabsi)       * afracr
+       end if
 
        ! Derived: compute total precipitation - scale total precip and runoff
 

--- a/driver_cpl/shr/seq_flds_mod.F90
+++ b/driver_cpl/shr/seq_flds_mod.F90
@@ -364,7 +364,7 @@ module seq_flds_mod
         flds_co2_dmsa = .false.
         glc_nec   = 0
         ice_ncat  = 1
-        seq_flds_i2o_per_cat = .true.
+        seq_flds_i2o_per_cat = .false.
 
         unitn = shr_file_getUnit()
         write(logunit,"(A)") subname//': read seq_cplflds_inparm namelist from: '&
@@ -524,14 +524,14 @@ module seq_flds_mod
      call seq_flds_add(dom_other,'mask')
      longname = ''
      stdname  = 'mask'
-     units    = 'unitless'
+     units    = '1'
      attname  = 'mask'
      call metadata_set(attname, longname, stdname, units)
 
      call seq_flds_add(dom_other,'frac')
      longname = 'area_fraction'
      stdname  = 'area fraction'
-     units    = 'unitless'
+     units    = '1'
      attname  = 'frac' 
      call metadata_set(attname, longname, stdname, units)
 
@@ -920,7 +920,7 @@ module seq_flds_mod
      call seq_flds_add(x2a_states,'Sf_ofrac')
      longname = 'Surface land fraction'
      stdname  = 'land_area_fraction'
-     units    = 'unitless'
+     units    = '1'
      attname  = 'Sf_lfrac'
      call metadata_set(attname, longname, stdname, units)
      longname = 'Surface ice fraction'
@@ -939,7 +939,7 @@ module seq_flds_mod
      call seq_flds_add(x2a_states,"Sx_avsdr")
      longname = 'Direct albedo (visible radiation)'
      stdname  = 'surface_direct_albedo_due_to_visible_radiation'
-     units    = 'unitless'
+     units    = '1'
      attname  = 'Si_avsdr'
      call metadata_set(attname, longname, stdname, units)
      attname  = 'Sl_avsdr'
@@ -956,7 +956,7 @@ module seq_flds_mod
      call seq_flds_add(x2a_states,"Sx_anidr")
      longname = 'Direct albedo (near-infrared radiation)'
      stdname  = 'surface_direct_albedo_due_to_near_infrared_radiation'
-     units    = 'unitless'
+     units    = '1'
      attname  = 'Si_anidr'
      call metadata_set(attname, longname, stdname, units)
      attname  = 'Sl_anidr'
@@ -973,7 +973,7 @@ module seq_flds_mod
      call seq_flds_add(x2a_states,"Sx_avsdf")
      longname = 'Diffuse albedo (visible radiation)'
      stdname  = 'surface_diffuse_albedo_due_to_visible_radiation'
-     units    = 'unitless'
+     units    = '1'
      attname  = 'Si_avsdf'
      call metadata_set(attname, longname, stdname, units)
      attname  = 'Sl_avsdf'
@@ -990,7 +990,7 @@ module seq_flds_mod
      call seq_flds_add(x2a_states,"Sx_anidf")
      longname = 'Diffuse albedo (near-infrared radiation)'
      stdname  = 'surface_diffuse_albedo_due_to_near_infrared_radiation'
-     units    = 'unitless'
+     units    = '1'
      attname  = 'Si_anidf'
      call metadata_set(attname, longname, stdname, units)
      attname  = 'Sl_anidf'
@@ -1312,7 +1312,7 @@ module seq_flds_mod
      call seq_flds_add(x2w_states,"Si_ifrac")
      longname = 'Fractional ice coverage wrt ocean'
      stdname  = 'sea_ice_area_fraction'
-     units    = 'unitless'
+     units    = '1'
      attname  = 'Si_ifrac'
      call metadata_set(attname, longname, stdname, units)
 
@@ -1416,7 +1416,7 @@ module seq_flds_mod
      call seq_flds_add(o2x_states,"So_fswpen")
      longname = 'Fraction of sw penetrating surface layer for diurnal cycle'
      stdname  = 'Fraction of sw penetrating surface layer for diurnal cycle'
-     units    = 'unitless'
+     units    = '1'
      attname  = 'So_fswpen'
      call metadata_set(attname, longname, stdname, units)
 
@@ -1746,7 +1746,7 @@ module seq_flds_mod
      call seq_flds_add(x2l_states_from_glc,trim(name))
      longname = 'Ice sheet grid coverage on global grid'
      stdname  = 'ice_sheet_grid_mask'
-     units    = 'unitless'
+     units    = '1'
      attname  = 'Sg_icemask'
      call metadata_set(attname, longname, stdname, units)     
 
@@ -1757,7 +1757,7 @@ module seq_flds_mod
      call seq_flds_add(x2l_states_from_glc,trim(name))
      longname = 'Ice sheet mask where we are potentially sending non-zero fluxes'
      stdname  = 'icemask_coupled_fluxes'
-     units    = 'unitless'
+     units    = '1'
      attname  = 'Sg_icemask_coupled_fluxes'
      call metadata_set(attname, longname, stdname, units)     
 
@@ -1813,7 +1813,7 @@ module seq_flds_mod
      name = 'Sg_ice_covered'
      longname = 'Fraction of glacier area'
      stdname  = 'glacier_area_fraction'
-     units    = 'unitless'    
+     units    = '1'    
      attname  = 'Sg_ice_covered'
      call seq_flds_add(g2x_states,trim(name))
      call seq_flds_add(g2x_states_to_lnd,trim(name))
@@ -1987,7 +1987,7 @@ module seq_flds_mod
            call seq_flds_add(x2o_states,name)
            longname = 'fractional ice coverage wrt ocean for thickness category ' // cnum
            stdname  = 'sea_ice_area_fraction'
-           units    = 'unitless'
+           units    = '1'
            attname  = name
            call metadata_set(attname, longname, stdname, units)
 
@@ -2010,7 +2010,7 @@ module seq_flds_mod
         call seq_flds_add(x2o_states,name)
         longname = 'fractional atmosphere coverage wrt ocean'
         stdname  = 'atmosphere_area_fraction'
-        units    = 'unitless'
+        units    = '1'
         attname  = name
         call metadata_set(attname, longname, stdname, units)
 
@@ -2018,7 +2018,7 @@ module seq_flds_mod
         call seq_flds_add(x2o_states,name)
         longname = 'fractional atmosphere coverage used in radiation computations wrt ocean'
         stdname  = 'atmosphere_area_fraction'
-        units    = 'unitless'
+        units    = '1'
         attname  = name
         call metadata_set(attname, longname, stdname, units)
 

--- a/driver_cpl/shr/seq_flds_mod.F90
+++ b/driver_cpl/shr/seq_flds_mod.F90
@@ -273,6 +273,8 @@ module seq_flds_mod
      character(len=CSS) :: units
      character(len=CSS) :: longname
      character(len=CSS) :: stdname
+     integer            :: num
+     character(len=  2) :: cnum
      character(len=CSS) :: name
 
      character(CXX) :: dom_coord  = ''

--- a/scripts/Tools/compare_namelists.pl
+++ b/scripts/Tools/compare_namelists.pl
@@ -23,17 +23,13 @@ my $cnt1=$#nlfile;
 my $cnt2=$#basenml;
 my $shiftbl=1;
 foreach $line (@nlfile){
-    chomp $line;
     my $bline = shift(@basenml) if($shiftbl);
-    chomp $line;
     $line =~ s/\s+/ /g;
     $bline =~ s/\s+/ /g;
     $shiftbl=1;
     next if($line eq $bline);
     $bline=shift(@basenml) if(($bline =~ /^\s*[#!\[\/]/) or ($bline =~ /^\s*$/));
-    chomp $bline;
 
-    next if($line eq $bline);
     next if(defined $baseid && $line =~ /$baseid/); 
     next if($line =~ /^\s*[#!\[\/]/);
     next if($line =~ /^\s*$/);
@@ -48,7 +44,8 @@ foreach $line (@nlfile){
     if($bline =~ /(.*)=(.*)/){
         $name2 = $1;
     }
-
+    chomp $line;
+    chomp $bline;
     if($name1 eq $name2){
 	push(@diffs1,$line);
 	push(@diffs2,$bline);
@@ -56,7 +53,6 @@ foreach $line (@nlfile){
 	push(@added,$line);
 	$shiftbl=0;
 	$cnt1--;
-	unshift(@basenml, $bline);
     }elsif($cnt2>$cnt1){
 	push(@removed,$bline);
 	shift(@basenml);

--- a/scripts/Tools/compare_namelists.pl
+++ b/scripts/Tools/compare_namelists.pl
@@ -23,13 +23,17 @@ my $cnt1=$#nlfile;
 my $cnt2=$#basenml;
 my $shiftbl=1;
 foreach $line (@nlfile){
+    chomp $line;
     my $bline = shift(@basenml) if($shiftbl);
+    chomp $line;
     $line =~ s/\s+/ /g;
     $bline =~ s/\s+/ /g;
     $shiftbl=1;
     next if($line eq $bline);
     $bline=shift(@basenml) if(($bline =~ /^\s*[#!\[\/]/) or ($bline =~ /^\s*$/));
+    chomp $bline;
 
+    next if($line eq $bline);
     next if(defined $baseid && $line =~ /$baseid/); 
     next if($line =~ /^\s*[#!\[\/]/);
     next if($line =~ /^\s*$/);
@@ -44,8 +48,7 @@ foreach $line (@nlfile){
     if($bline =~ /(.*)=(.*)/){
         $name2 = $1;
     }
-    chomp $line;
-    chomp $bline;
+
     if($name1 eq $name2){
 	push(@diffs1,$line);
 	push(@diffs2,$bline);
@@ -53,6 +56,7 @@ foreach $line (@nlfile){
 	push(@added,$line);
 	$shiftbl=0;
 	$cnt1--;
+	unshift(@basenml, $bline);
     }elsif($cnt2>$cnt1){
 	push(@removed,$bline);
 	shift(@basenml);

--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -160,6 +160,9 @@ if($dryrun){
 # Create namelists
 # -------------------------------------------------------------------------
 
+# Note - COMP_CPL must be last so that it can use xml vars potentially set 
+# by other component's buildnml scripts
+
 my @modelsorder = qw( atm lnd ice ocn glc wav rof drv );
 
 my %models = ( atm => $COMP_ATM, lnd => $COMP_LND, ice => $COMP_ICE,


### PR DESCRIPTION
Optionally pass subgrid shortwave flux to ocean

Add feature to optionally pass additional fields to the ocean:

Additional ice to ocean fields, indexed as a 2 digit number nn, are:
  Si_ifrac_nn           : ice fraction
  PFioi_swpen_ifrac_nn  : swpen \* ice fraction

Additional cpl to ocean fields are:
  Sf_afrac              : open ocean fraction
  Sf_afracr             : open ocean fraction used in rad computations
  Foxx_swnet_afracr     : swnet \* Sf_afracr

These new fields are passed if the seq_flds_i2o_per_cat is .true. This
is a new namelist variable in seq_cplflds_inparm (default=.false.). It is
set based on new the env_run.xml variable CPL_I2O_PER_CAT (default=FALSE).

The number of ice thickness categories is propagated to the coupled
system through the namelist variable ice_ncat in seq_cplflds_inparm
(default=1). It is set based on the new env_build.xml variable ICE_NCAT
(default=1).

Increase string length (80->CSS) for cpl hist metadata.

Change units from 'units' to '1' for all cell fractions and albedos.

Add comment to preview_namelists indicating that buildnml for COMP_CPL
needs to be executed last.

Add code to dice to pass these fields if requested.

Correct type of the following dice namelist variables (logical->real):
flux_qacc0, flux_qmin, flux_swpf

Test suite: aux_pop_MARBL

Test baseline: /glade/scratch/mlevy/baselines/aux_pop_marbl_20151020
               (based on cime4.1.2 and pop trunk from 20151020)

Test namelist changes:
ice_ncat, seq_flds_i2o_percat added to seq_cplflds_inparm

Test status: bit for bit

Fixes: none

User interface changes?: No

Code review: mvertens, jedwards
