### PR TITLE
remove code that was causing a meaningless error message

### DIFF
--- a/cime_config/cesm/machines/template.cesmrun
+++ b/cime_config/cesm/machines/template.cesmrun
@@ -36,7 +36,6 @@ require Depends::Checks;
 require Module::ModuleLoader;
 require Batch::BatchUtils;
 require Log::Log4perl;
-require Log::Log4perl::Appender::Screen;
 my $logger;
 
 
@@ -92,12 +91,6 @@ sub getOptions()
 			  layout=>'%m%n'});
     
     $logger = Log::Log4perl::get_logger();
-# By default logger writes to stderr - redirect to stdout
-    my $app = Log::Log4perl::Appender::Screen->new(
-      stderr    => 0,
-    );
-    $logger->add_appender($app);
-
 
 
     # First, get the configuration from xml . 


### PR DESCRIPTION
Remove code that was causing an error message to stdout

the Log4perl::Appender::Screen method has some issues, this code in 
template.cesmrun was causing an error message to stderr which really 
didn't make sense.

Test suite:  yellowstone drv prealpha
Test baseline: none used 
Test namelist changes: none
Test status: bit for bit

Fixes: 

Code review: 
