### PR TITLE
Bring back driver changes reverted in cime4.0.3

### DIFF
--- a/driver_cpl/driver/cesm_comp_mod.F90
+++ b/driver_cpl/driver/cesm_comp_mod.F90
@@ -428,7 +428,8 @@ module cesm_comp_mod
    character(CL) :: hist_a2x_flds     = 'Faxa_swndr:Faxa_swvdr:Faxa_swndf:Faxa_swvdf'
 !  character(CL) :: hist_a2x24hr_flds = 'all'
    character(CL) :: hist_a2x3hrp_flds = 'Faxa_rainc:Faxa_rainl:Faxa_snowc:Faxa_snowl'
-   character(CL) :: hist_a2x3hr_flds  = 'Sa_z:Sa_u:Sa_v:Sa_tbot:Sa_ptem:Sa_shum:Sa_dens:Sa_pbot:Sa_pslv:Faxa_lwdn:&
+   character(CL) :: hist_a2x3hr_flds  = &
+        'Sa_z:Sa_topo:Sa_u:Sa_v:Sa_tbot:Sa_ptem:Sa_shum:Sa_dens:Sa_pbot:Sa_pslv:Faxa_lwdn:&
         &Faxa_rainc:Faxa_rainl:Faxa_snowc:Faxa_snowl:&
         &Faxa_swndr:Faxa_swvdr:Faxa_swndf:Faxa_swvdf'
 


### PR DESCRIPTION
Some changes to the driver were accidentally reverted in cime4.0.3
relative to cime4.0.2. This commit brings them back.

Test suite: drv prealpha yellowstone
Test baseline: cesm1_5_beta02
Test namelist changes: Yes, presumed due to other changes since beta02
Test status: bit for bit

Fixes: #287

User interface changes?: No

Code review: None
