### PR TITLE
stdout message fix 

### DIFF
--- a/cime_config/cesm/config_grids.xml
+++ b/cime_config/cesm/config_grids.xml
@@ -236,11 +236,20 @@
       <lname>a%0.23x0.31_l%0.23x0.31_oi%0.23x0.31_r%r05_m%gx1v6_g%null_w%null</lname>
     </grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQUAP)">
+    <grid compset="(DOCN|XOCN|SOCN|AQUAP).+SGLC">
       <sname>0.9x1.25_0.9x1.25</sname>
       <alias>f09_f09</alias>
       <lname>a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_m%gx1v6_g%null_w%null</lname>
     </grid>
+
+
+    <grid compset="(DOCN|XOCN|SOCN|AQUAP).+CISM1">
+      <sname>0.9x1.25_0.9x1.25</sname>
+      <alias>f09_f09</alias>
+      <lname>a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_m%gx1v6_g%gland5UM_w%null</lname>
+    </grid>
+
+
 
     <grid compset="(DOCN|XOCN|SOCN|AQUAP)">
       <sname>1.9x2.5_1.9x2.5</sname>

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -421,7 +421,7 @@
   </machine>
 
   <machine MACH="corip1">
-    <DESC>NERSC XC30 Haswell, os is CNL, 24 pes/node, batch system is Slurm</DESC>
+    <DESC>NERSC XC40 Haswell, os is CNL, 32 pes/node, batch system is Slurm</DESC>
     <COMPILERS>intel,gnu,cray</COMPILERS>
     <MPILIBS>mpt,mpi-serial</MPILIBS>
     <CESMSCRATCHROOT>$ENV{SCRATCH}</CESMSCRATCHROOT>
@@ -460,7 +460,7 @@
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n {{ num_tasks }}</arg>
 
-	<arg name="thread_count" > -c {{ thread_count }}</arg>
+     	<arg name="thread_count" > -c {{ thread_count }}</arg>
 
       </arguments>
     </mpirun>
@@ -495,7 +495,15 @@
 	<command name="load">PrgEnv-intel</command>
 	<command name="switch">intel intel/2016.0.109</command>
 	<command name="rm">cray-libsci</command>
+	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
       </modules>
+      <modules compiler="intel" mpilib="!mpi-serial" >
+	<command name="load">esmf/6.3.0rp1-defio-intel2016-mpi-0</command>
+      </modules>
+      <modules compiler="intel" mpilib="mpi-serial" >
+        <command name="load">esmf/6.3.0rp1-defio-intel2016-mpiuni-0</command>
+      </modules>
+
       <modules compiler="cray">
 	<command name="load">PrgEnv-cray</command>
 	<command name="switch">cce cce/8.4.0</command>
@@ -532,114 +540,6 @@
     </environment_variables>
   </machine>
 
-  <machine MACH="corip1">
-    <DESC>NERSC XC30 Haswell, os is CNL, 24 pes/node, batch system is Slurm</DESC>
-    <COMPILERS>intel,gnu,cray</COMPILERS>
-    <MPILIBS>mpt,mpi-serial</MPILIBS>
-    <CESMSCRATCHROOT>$ENV{SCRATCH}</CESMSCRATCHROOT>
-    <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>
-    <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
-    <DIN_LOC_ROOT>/project/projectdirs/ccsm1/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/ccsm1/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-    <DOUT_S_ROOT>$CESMSCRATCHROOT/archive/$CASE</DOUT_S_ROOT>
-    <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-    <CCSM_BASELINE>/project/projectdirs/ccsm1/ccsm_baselines</CCSM_BASELINE>
-    <CCSM_CPRNC>/project/projectdirs/ccsm1/tools/cprnc.edison/cprnc</CCSM_CPRNC>
-    <OS>CNL</OS>
-    <BATCHQUERY>squeue</BATCHQUERY>
-    <BATCHSUBMIT>sbatch</BATCHSUBMIT>
-    <BATCHREDIRECT></BATCHREDIRECT>
-    <SUPPORTED_BY>cseg</SUPPORTED_BY>
-    <GMAKE_J>8</GMAKE_J>
-    <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>32</PES_PER_NODE>
-    <batch_system type="slurm" version="x.y">
-      <queues>
-        <queue walltimemax="00:06:00" jobmin="1" jobmax="16384" >regular</queue>
-        <queue walltimemax="00:04:00" jobmin="16385" jobmax="32768" >regular</queue>
-        <queue walltimemax="00:02:00" jobmin="32769" jobmax="52096" >regular</queue>
-	<queue walltimemax="00:30:00" jobmin="1" jobmax="4096" default="true">debug</queue>
-      </queues>
-      <walltimes>
-	<walltime default="true">00:30:00</walltime>
-	<walltime ccsm_estcost="1">01:50:00</walltime>
-	<walltime ccsm_estcost="3">05:00:00</walltime>
-      </walltimes>
-    </batch_system>
-    <mpirun mpilib="default">
-      <executable>srun</executable>
-      <arguments>
-	<arg name="label"> --label</arg>
-	<arg name="num_tasks" > -n {{ num_tasks }}</arg>
-
-	<arg name="thread_count" > -c {{ thread_count }}</arg>
-
-      </arguments>
-    </mpirun>
-    <module_system type="module">
-      <init_path lang="perl">/opt/modules/default/init/perl.pm</init_path>
-      <init_path lang="sh">/opt/modules/default/init/sh</init_path>
-      <init_path lang="csh">/opt/modules/default/init/csh</init_path>
-      <cmd_path lang="perl">/opt/modules/default/bin/modulecmd perl</cmd_path>
-      <cmd_path lang="sh">module</cmd_path>
-      <cmd_path lang="csh">module</cmd_path>
-      <modules>
-	<command name="rm">PrgEnv-intel</command>
-	<command name="rm">PrgEnv-cray</command>
-	<command name="rm">PrgEnv-gnu</command>
-	<command name="rm">intel</command>
-	<command name="rm">cce</command>
-	<command name="rm">cray-parallel-netcdf</command>
-	<command name="rm">cray-parallel-hdf5</command>
-	<command name="rm">pmi</command>
-	<command name="rm">cray-libsci</command>
-	<command name="rm">cray-mpich2</command>
-	<command name="rm">cray-mpich</command>
-	<command name="rm">cray-netcdf</command>
-	<command name="rm">cray-hdf5</command>
-	<command name="rm">cray-netcdf-hdf5parallel</command>
-	<command name="rm">craype-sandybridge</command>
-	<command name="rm">craype-ivybridge</command>
-	<command name="rm">craype</command>
-      </modules>
-      
-      <modules compiler="intel">
-	<command name="load">PrgEnv-intel</command>
-	<command name="switch">intel intel/2016.0.109</command>
-	<command name="rm">cray-libsci</command>
-      </modules>
-      <modules compiler="cray">
-	<command name="load">PrgEnv-cray</command>
-	<command name="switch">cce cce/8.4.0</command>
-      </modules>
-      <modules compiler="gnu">
-	<command name="load">PrgEnv-gnu</command>
-	<command name="switch">gcc gcc/5.1.0</command>
-      </modules>
-      <modules>
-	<command name="load">papi/5.4.1.2</command>
-	<command name="swap">craype craype/2.4.2</command>
-      </modules>
-      <modules compiler="!intel">
-	<command name="switch">cray-libsci/13.2.0</command>
-      </modules>
-      <modules>
-	<command name="load">cray-mpich/7.2.5</command>
-      </modules>
-      <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.8.14</command>
-	<command name="load">cray-netcdf/4.3.3.1</command>
-      </modules>
-      <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.3.3.1</command>
-	<command name="load">cray-hdf5-parallel/1.8.14</command>
-	<command name="load">cray-parallel-netcdf/1.6.1</command>
-      </modules>
-      <modules>
-	<command name="load">cmake/3.3.2</command>
-      </modules>
-    </module_system>
-  </machine>
 
   <machine MACH="eastwind">
     <DESC>PNL IBM Xeon cluster, os is Linux (pgi), batch system is SLURM</DESC>

--- a/cime_config/cesm/machines/template.cesmrun
+++ b/cime_config/cesm/machines/template.cesmrun
@@ -235,7 +235,7 @@ sub checkInputData()
 	$logger->logdie( "ERROR, the input data directory $config{'DIN_LOC_ROOT'} cannot be found!");
     }
     
-    open(F,"./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -check -loglevel $opts{$loglevel} |" );
+    open(F,"./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -check -loglevel $opts{loglevel} |" );
     my @inputdatacheck = <F>;
     close(F);
     my @unknown = grep { /unknown/ } @inputdatacheck;
@@ -248,16 +248,16 @@ sub checkInputData()
         $out.="expected location, and are not from the input data repository.\n";
         $out.="This is informational only.\n";
 	$logger->warn($out);
-	system("./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -check -loglevel $opts{$loglevel}");
+	system("./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -check -loglevel $opts{loglevel}");
     }
     
     if(@missing)
     {
 	$logger->info( "Attempting to download missing data:");
-	system("./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -export -loglevel $opts{$loglevel}");
+	system("./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -export -loglevel $opts{loglevel}");
     }
     
-    open(F,"./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -check -loglevel $opts{$loglevel} |" );
+    open(F,"./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -check -loglevel $opts{loglevel} |" );
     my @potmissing  = <F>;
     close(F);
     @missing = grep { /missing/ } @potmissing;
@@ -490,7 +490,7 @@ sub resubmitCheck()
 	my $submitscript = "$config{'CASEROOT'}/case.submit";
 	my $cwd = getcwd;
 	chdir $config{'CASEROOT'};
-	my $resubmitcommand = "$submitscript -resubmit -scriptname case. -loglevel $opts{$loglevel}";
+	my $resubmitcommand = "$submitscript -resubmit -scriptname case. -loglevel $opts{loglevel}";
 
 	if(defined $config{TESTCASE} && $config{TESTCASE} eq "ERR"){
 	    $resubmitcommand .= "test"; 

--- a/cime_config/cesm/machines/template.cesmrun
+++ b/cime_config/cesm/machines/template.cesmrun
@@ -161,68 +161,66 @@ sub doPreRunChecks()
     {
         $ENV{'MP_MPILIB'} = $mpilib;
     }
-        $config{'MPILIB'} = $mpilib;
+    $config{'MPILIB'} = $mpilib;
 	
-	$logger->debug( "build complete? $config{'BUILD_COMPLETE'}");
-	if($config{'BUILD_COMPLETE'} ne 'TRUE')
-	{
-		$logger->logdie("BUILD_COMPLETE is not true\nPlease rebuild the model interactively");
-	}
+    $logger->debug( "build complete? $config{'BUILD_COMPLETE'}");
+    if($config{'BUILD_COMPLETE'} ne 'TRUE')
+    {
+	$logger->logdie("BUILD_COMPLETE is not true\nPlease rebuild the model interactively");
+    }
 	
-	$ENV{'LBQUERY'} = "TRUE";
-	if( ! defined $config{'BATCHSUBMIT'} || length $config{'BATCHSUBMIT'} == 0)
-	{
-		$ENV{'LBQUERY'} = "FALSE";
-		$ENV{'BATCHQUERY'} = "undefined";
-	}
+    $ENV{'LBQUERY'} = "TRUE";
+    if( ! defined $config{'BATCHSUBMIT'} || length $config{'BATCHSUBMIT'} == 0)
+    {
+	$ENV{'LBQUERY'} = "FALSE";
+	$ENV{'BATCHQUERY'} = "undefined";
+    }
+    
+    elsif ( $config{'BATCHSUBMIT'} eq 'UNSET')
+    {
+	$ENV{'LBSUBMIT'} = "FALSE";
+	$ENV{'BATCHSUBMIT'} = "undefined";
+    }
+    
+    ## Create the timing directories, optionally cleaning them if needed. 
+    if(! -d $config{'RUNDIR'})
+    {
+	mkpath($config{'RUNDIR'}) or die "could not crate $config{'RUNDIR'}, exiting\n";
+    }
+    if(-d "$config{'RUNDIR'}/timing")
+    {
+	rmtree("$config{'RUNDIR'}/timing");
+    }
+    # Now make the timing and timing/checkpoints directories..
+    mkpath("$config{'RUNDIR'}/timing/checkpoints");
+    
+    # Now set up the LID and sdate? strings
+    $LID = strftime("%y%m%d-%H%M%S", localtime);
+    my $sdate = strftime("%Y-%m-%d %H:%M:%S", localtime);
+    $ENV{'LID'} = $LID;
+    $ENV{'sdate'} = $sdate;
 	
-	elsif ( $config{'BATCHSUBMIT'} eq 'UNSET')
-	{
-		$ENV{'LBSUBMIT'} = "FALSE";
-		$ENV{'BATCHSUBMIT'} = "undefined";
-	}
+    open my $CS, ">>", "./CaseStatus" or die "Could not open CaseStatus file for writing!";
+    print $CS "run started $sdate\n";
+    close $CS;
 	
-	## Create the timing directories, optionally cleaning them if needed. 
-	if(! -d $config{'RUNDIR'})
-	{
-		mkpath($config{'RUNDIR'}) or die "could not crate $config{'RUNDIR'}, exiting\n";
-	}
-	if(-d "$config{'RUNDIR'}/timing")
-	{
-		rmtree("$config{'RUNDIR'}/timing");
-	}
-	# Now make the timing and timing/checkpoints directories..
-	mkpath("$config{'RUNDIR'}/timing/checkpoints");
+    $logger->info( "-------------------------------------------------------------------------");
+    $logger->info(" BUILDNML SCRIPT STARTING");
+    $logger->info(" - To prestage restarts, untar a restart.tar file into $config{'RUNDIR'}");
 	
-	# Now set up the LID and sdate? strings
-	$LID = strftime("%y%m%d-%H%M%S", localtime);
-	my $sdate = strftime("%Y-%m-%d %H:%M:%S", localtime);
-	$ENV{'LID'} = $LID;
-	$ENV{'sdate'} = $sdate;
+    # Run preview namelists.. should turn this into a module at some point..
+    system("./preview_namelists -loglevel $opts{loglevel}");
 	
-	open my $CS, ">>", "./CaseStatus" or die "Could not open CaseStatus file for writing!";
-	print $CS "run started $sdate\n";
-	close $CS;
+    if($?)
+    {
+	$logger->logdie("ERROR from preview namelist - EXITING");
+    }
 	
-	$logger->info( "-------------------------------------------------------------------------");
-        $logger->info(" BUILDNML SCRIPT STARTING");
-	$logger->info(" - To prestage restarts, untar a restart.tar file into $config{'RUNDIR'}");
-	
-	# Run preview namelists.. should turn this into a module at some point..
-	my @previewoutput = qx("./preview_namelists");
-	map { print $_ } @previewoutput;
-	
-	if($?)
-	{
-	    $logger->logdie("ERROR from preview namelist - EXITING");
-	       
-	}
-	
-	$logger->info( " BUILDNML SCRIPT HAS FINISHED SUCCESSFULLY");
-	$logger->info( "-------------------------------------------------------------------------");
-	$logger->info( " PRESTAGE SCRIPT STARTING");
-	$logger->info(" - Case input data directory, DIN_LOC_ROOT, is $config{'DIN_LOC_ROOT'}");
-	$logger->info( " - Checking the existence of input datasets in DIN_LOC_ROOT");
+    $logger->info( " BUILDNML SCRIPT HAS FINISHED SUCCESSFULLY");
+    $logger->info( "-------------------------------------------------------------------------");
+    $logger->info( " PRESTAGE SCRIPT STARTING");
+    $logger->info(" - Case input data directory, DIN_LOC_ROOT, is $config{'DIN_LOC_ROOT'}");
+    $logger->info( " - Checking the existence of input datasets in DIN_LOC_ROOT");
 
 }
 
@@ -237,7 +235,9 @@ sub checkInputData()
 	$logger->logdie( "ERROR, the input data directory $config{'DIN_LOC_ROOT'} cannot be found!");
     }
     
-    my @inputdatacheck = qx(./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -check );
+    open(F,"./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -check -loglevel $opts{$loglevel} |" );
+    my @inputdatacheck = <F>;
+    close(F);
     my @unknown = grep { /unknown/ } @inputdatacheck;
     my @missing = grep { /missing/ } @inputdatacheck;
     
@@ -248,23 +248,23 @@ sub checkInputData()
         $out.="expected location, and are not from the input data repository.\n";
         $out.="This is informational only.\n";
 	$logger->warn($out);
-	qx(./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -check);
+	system("./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -check -loglevel $opts{$loglevel}");
     }
     
     if(@missing)
     {
 	$logger->info( "Attempting to download missing data:");
-	qx(./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -export);
+	system("./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -export -loglevel $opts{$loglevel}");
     }
     
-    my @potmissing  = qx(./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -check );
+    open(F,"./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -check -loglevel $opts{$loglevel} |" );
+    my @potmissing  = <F>;
+    close(F);
     @missing = grep { /missing/ } @potmissing;
     if(@missing)
     {
-	my @notfound = qx(./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -check);
-	
 	my $out = "The following files were not found, they are required\n";
-	$out .= map { print $_ } @notfound;
+	$out .= map { print $_ } @potmissing;
 	$out .= "Invoke the following command to obtain them:\n";
 	$out .= " ./check_input_data -inputdata $config{'DIN_LOC_ROOT'} -export ";
         $logger->logdie($out);
@@ -459,7 +459,7 @@ sub postRun()
         my $timingDir = $config{'CASEROOT'} . "/timing";
         mkpath $timingDir if(! -e $timingDir);
         $logger->info( "running timing script..");
-        qx( $config{'CASETOOLS'}/getTiming -lid $LID );
+        system(" $config{'CASETOOLS'}/getTiming -lid $LID ");
         $logger->info( "gzipping timing stats..");
         qx( gzip timing/cesm_timing_stats.$LID );
     }
@@ -490,7 +490,7 @@ sub resubmitCheck()
 	my $submitscript = "$config{'CASEROOT'}/case.submit";
 	my $cwd = getcwd;
 	chdir $config{'CASEROOT'};
-	my $resubmitcommand = "$submitscript -resubmit -scriptname case.";
+	my $resubmitcommand = "$submitscript -resubmit -scriptname case. -loglevel $opts{$loglevel}";
 
 	if(defined $config{TESTCASE} && $config{TESTCASE} eq "ERR"){
 	    $resubmitcommand .= "test"; 
@@ -498,7 +498,7 @@ sub resubmitCheck()
 	    $resubmitcommand .= "run"; 
 	}
 	$logger->debug( "running resubmit check $resubmitcommand");    
-	qx($resubmitcommand);
+	system($resubmitcommand);
         if($?){ $logger->warn ("could not run CESM submit script, $! $?");}
 	chdir $cwd;
     }
@@ -510,7 +510,7 @@ sub DoDataAssimilation
 
     return unless($da eq "TRUE");
 
-    qx( $da_script 1> da.log.$lid 2>&1);
+    system(" $da_script 1> da.log.$lid 2>&1");
     sleep(1);
     $logger->logdie ("$da_script failed") unless ($? == 0);
     chdir $rundir;

--- a/cime_config/cesm/machines/template.starchive
+++ b/cime_config/cesm/machines/template.starchive
@@ -47,7 +47,7 @@ if(-e $testlog){
     close(TL);
 }
 $logger->info("st_archive starting");
-qx(./st_archive >> stArchiveStatus 2>&1);
+system("./st_archive >> stArchiveStatus 2>&1");
 if(-e $testlog){
     open(TL,">>$testlog");
     print TL "st_archive complete\n";
@@ -63,14 +63,14 @@ sub resubmitCheck()
 	my $submitscript = "$config{'CASEROOT'}/case.submit";
 	my $cwd = getcwd;
 	chdir $config{CASEROOT};
-	my $resubmitcommand = "$submitscript -resubmit -scriptname case.st_archive";
+	my $resubmitcommand = "$submitscript -resubmit -scriptname case.st_archive -loglevel $opts{$loglevel}";
 	$logger->debug( "running resubmit check $resubmitcommand");
 	if(-e $testlog){
 	    open(TL,">>$testlog");
 	    print TL "running resubmit check $resubmitcommand\n";
 	    close(TL);
 	}
-	qx($resubmitcommand);
+       system($resubmitcommand);
         if($?){ $logger->warn ("could not run CESM submit script, $! $?");}
 	chdir $cwd;
     }

--- a/cime_config/cesm/machines/template.starchive
+++ b/cime_config/cesm/machines/template.starchive
@@ -63,7 +63,7 @@ sub resubmitCheck()
 	my $submitscript = "$config{'CASEROOT'}/case.submit";
 	my $cwd = getcwd;
 	chdir $config{CASEROOT};
-	my $resubmitcommand = "$submitscript -resubmit -scriptname case.st_archive -loglevel $opts{$loglevel}";
+	my $resubmitcommand = "$submitscript -resubmit -scriptname case.st_archive -loglevel $opts{loglevel}";
 	$logger->debug( "running resubmit check $resubmitcommand");
 	if(-e $testlog){
 	    open(TL,">>$testlog");

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -239,7 +239,10 @@ sub checkInputData()
     my $RUNDIR		= `./xmlquery RUNDIR		-value`;
     my $CONTINUE_RUN	= `./xmlquery CONTINUE_RUN	-value`;
 
-    my @inputdatacheck = qx(./check_input_data -inputdata $DIN_LOC_ROOT -check);
+    
+    open(F," ./check_input_data -inputdata $DIN_LOC_ROOT -check |");
+    my @inputdatacheck = <F>;
+    close(F);
 
     my @unknown = grep { /unknown/ } @inputdatacheck;
     if (@unknown) {
@@ -252,11 +255,13 @@ sub checkInputData()
     my @missing = grep { /missing/ } @inputdatacheck;
     if (@missing) {
 	$logger->info("Attempting to download missing data");
-	qx(./check_input_data -inputdata $DIN_LOC_ROOT -export);
+	system("./check_input_data -inputdata $DIN_LOC_ROOT -export");
 
 	$logger->info("Now checking if required input data is in $DIN_LOC_ROOT ");
 
-	@inputdatacheck = qx(./check_input_data -inputdata $DIN_LOC_ROOT -check);
+	open(F,"./check_input_data -inputdata $DIN_LOC_ROOT -check |");
+	@inputdatacheck = <F>;
+	close(F);
 	@missing = grep { /missing/ } @inputdatacheck;
 	if (@missing) {
 	    $logger->logdie( "The following files were not found, they are required".
@@ -507,7 +512,7 @@ sub buildLibraries()
 	my $file_build = "$SHAREDPATH/$lib.bldlog.$LID";
 	my $now = localtime;
 	$logger->info( "      $now $file_build");
-	open my $FB, ">", $file_build or die $!;
+	open my $FB, ">", $file_build or $logger->logdie( $!);
 	map { print $FB "$_: $ENV{$_}\n"} sort keys %ENV;
 	close $FB;
 	

--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -12,6 +12,8 @@ use IO::File;
 use IO::Handle;
 use File::Basename;
 use File::Copy;
+
+
 #-----------------------------------------------------------------------------------------------
 sub usage {
     die <<EOF;
@@ -316,8 +318,8 @@ if (! $clean ) {
     #--------------------------------------------------------------------------
     # Run preview namelists for scripts
     #--------------------------------------------------------------------------
-    $logger->info("Running preview_namelist script ");
-    qx( $caseroot/preview_namelists -loglevel $opts{loglevel} );
+    $logger->info("Running preview_namelist script with loglevel $opts{loglevel}");
+    system(" $caseroot/preview_namelists -loglevel $opts{loglevel} ");
     if($?){
 	$logger->logdie("ERROR: $caseroot/preview_namelists failed: $?")
     }

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -49,7 +49,7 @@ sub main
     # Check the case only once..
     if(!$opts{resubmit}){
 	$logger->info( "checking the case..");
-	qx(./check_case -loglevel $opts{loglevel});
+	system("./check_case -loglevel $opts{loglevel}");
 	if($?)
 	{
 	    $logger->error( "check_case failed");

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -25,7 +25,7 @@ OPTIONS
      -prestage <prestage>   Prestage data from inputdata to prestage
      -datalistdir <dir>     Directory which will be searched for .input_data_list files
                             Default is $CASEROOT/Buildconf.  Optional.
-     -verbose [or -v]       Print extra information. Optional.
+     -loglevel             Set output verbosity. Optional.
      -help [or -h]          Print usage to STDOUT.  Optional.
 SUMMARY
 
@@ -46,7 +46,7 @@ my %opts = ( inputdata      => undef,
 	     export         => 0,
 	     prestage       => 0,
 	     datalistdir    => undef,
-	     verbose        => 0,
+	     loglevel => "INFO",
 	     help           => 0
 	    );
 
@@ -56,25 +56,38 @@ GetOptions(
     "export"                    => \$opts{'export'},
     "prestage=s"                => \$opts{'prestage'},
     "datalistdir=s"             => \$opts{'datalistdir'},
-    "v|verbose"                 => \$opts{'verbose'},
+    "loglevel=s"                 => \$opts{'loglevel'},
     "h|help"                    => \$opts{'help'},
 )  or usage();
+
+
+$CIMEROOT		= `./xmlquery  CIMEROOT		-value `;
+my $perl5libdir = "$CIMEROOT/utils/perl5lib";
+push(@INC, $perl5libdir);
+require Log::Log4perl;
+
+my $level = Log::Log4perl::Level::to_priority($opts{loglevel});
+Log::Log4perl->easy_init({level=>$level,
+			  layout=>'%m%n'});
+
+
+my $logger = Log::Log4perl::get_logger("check_input_data");
 
 # Give usage message.
 usage() if $opts{'help'};
 
+
 # Check for unparsed arguments
 if (@ARGV) {
-    print "ERROR: unrecognized arguments: @ARGV\n";
+    $logger->error( "ERROR: unrecognized arguments: @ARGV");
     usage();
 }
 
 $opts{'check'} ? ($checkopt = 1) : ($checkopt = 0);
 $opts{'export'} ? ($exportopt = 1) : ($exportopt = 0);
 $opts{'prestage'} ? ($prestageopt = 1) : ($prestageopt = 0);
-$opts{'verbose'} ? ($verboseopt = 1) : ($verboseopt = 0);
 
-##print "opts $checkopt $exportopt $prestageopt \n";
+$logger->debug( "opts $checkopt $exportopt $prestageopt ");
 
 if (!$checkopt && !$exportopt && !$prestageopt) {
   usage();
@@ -95,9 +108,9 @@ else {
 ##print "datalistdir $opts{'datalistdir'}\n";
 
 # Check that input directory exists.
-(-d $opts{'datalistdir'})  or  die <<EOF;
-** $ProgName - Cannot find input directory: \"$opts{'datalistdir'}\" **
-EOF
+(-d $opts{'datalistdir'})  or  
+    $logger->logdie("** $ProgName - Cannot find input directory: \"$opts{'datalistdir'}\" **");
+
 
 # Check that the inputdata root directory has been specified.
 my $inputdata_rootdir = undef;
@@ -105,29 +118,24 @@ if (defined($opts{'inputdata'})) {
     $inputdata_rootdir = $opts{'inputdata'};
 }
 else {
-    die "$ProgName - ERROR: inputdata root directory must be specified by the -inputdata argument\n";
+    $logger->logdie ("$ProgName - ERROR: inputdata root directory must be specified by the -inputdata argument");
 }
 
 # The inputdata root directory must be local or nfs mounted.
-(-d $inputdata_rootdir)  or  die <<EOF;
-** $ProgName - inputdata root is not a directory: \"$inputdata_rootdir\" **
-EOF
+(-d $inputdata_rootdir)  or  
+    $logger->logdie("** $ProgName - inputdata root is not a directory: \"$inputdata_rootdir\" **");
 
 # Check prestage dir
 if ($prestageopt) {
     $prestage_rootdir = $opts{'prestage'};
-    (-d $prestage_rootdir)  or  die <<EOF;
-** $ProgName - prestage dir is not a directory: \"$prestage_rootdir\" **
-EOF
+    (-d $prestage_rootdir)  or  
+	$logger->logdie("** $ProgName - prestage dir is not a directory: \"$prestage_rootdir\" **");
 }
 
 # Find .input_data_list files
 @filelocations = `find "$opts{'datalistdir'}" -name '*.input_data_list'`;
 
-if ($verboseopt) {
-    print "Input Data List Files Found:\n";
-    print @filelocations;
-}
+$logger->debug( "Input Data List Files Found:\n@filelocations");
 
 # Determine if will prestage input data
 if ($prestageopt) {
@@ -144,15 +152,10 @@ my $svn_loc = 'https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata/';
 if ($exportopt) {
   my $error = `svn --version 2> /dev/null`;
   if ($error eq '') {
-    die "Error: the subversion client svn was not found.\n";
+    $logger->logdie ("Error: the subversion client svn was not found.");
   }
   my $error = `svn list $svn_loc > /dev/null`;
-#  my @error = `svn list $svn_loc 2>&1`;
-#  @found=grep(/atm\//g,@error);
-#  chomp(@found);
-#  if (length($found[0]) == 0){
-#    die ("@error \n");
-#  } 
+
 }
 
 $inputdata_rootdir .= "/";
@@ -172,16 +175,16 @@ foreach $i (@filelocations) {
 #    get_input_data ($flist, $inputdata_rootdir, $din_loc_root, $exportopt, $copyfiles);
 
     # Open input file.
-    open(filelist,$flist) or die <<EOF;
-** $ProgName - Cannot open input file: \"$flist\" **
-EOF
+    open(filelist,$flist) or
+	$logger->logdie("** $ProgName - Cannot open input file: \"$flist\" **");
+
     # Search for filenames in file. Note that all strings following " = " are assumed to be filenames.
     while(<filelist>) {
 	my $filend = "undefined";
         my $fileneed = $_;
         my $isinput = 0;
         my $docheck = 0;
-	#        print "tcx fn1 is $fileneed\n";
+	$logger->debug("tcx fn1 is $fileneed");
         if ($fileneed =~ m/(\S*)\#.*/) {
            $fileneed = $1;
            $docheck = 0;
@@ -200,15 +203,11 @@ EOF
         }
 
         # If any values have variables in them, read in xml variables and expand
-	my $xml = XML::LibXML->new( no_blanks => 1)->parse_file("env_case.xml"); 
-	my @nodes = $xml->findnodes(".//entry[\@id=\"CIMEROOT\"]"); 
-	my $cimeroot = $nodes[0]->getAttribute('value');
 
-	unshift @INC, "$cimeroot/utils/perl5lib";
 	require Config::SetupTools;
 
         if ($fileneed =~ m/\$/) {
-           print "Print expand any xml variables for: $fileneed\n";
+           $logger->debug( " expand any xml variables for: $fileneed");
 
            my %xmlvars = ();
            foreach my $file ( glob("env_*xml") ) {
@@ -227,7 +226,7 @@ EOF
         if ($docheck) {
            if (($checkopt)  && ($fileneed =~ m/.*(\w)+.*/)) {
 	      if (! -e $fileneed) {
-                 print "File is missing: $fileneed \n";
+                 $logger->warn( "File is missing: $fileneed ");
                  $status = 1;
               }
            }
@@ -235,7 +234,7 @@ EOF
 	      my $fileloc = $svn_loc.$filend;     # Location in subversion repository.
   	      my $lsearch = $fileloc;             # Variable used in  searches for symbolic links.
 	      isinrepository($fileloc) ? dataexport($fileneed, $fileloc) : 
-		 print "File was not found in svn repo: $fileloc \n";
+		 $logger->warn( "File was not found in svn repo: $fileloc ");
 	   }
 	   if (($isinput) && ($prestageopt)) {
 	      my $filecopy = $prestage_rootdir.$filend;
@@ -243,13 +242,13 @@ EOF
               if (-d $fileneed) {
                  system("umask 2; mkdir -p -m 775 $dirname");
 	         system("cp $fileneed/* $filecopy/ 2>/dev/null");
-                 print "Dir  copied to: $filecopy \n";
+                 $logger->info( "Dir  copied to: $filecopy ");
               } else {
                  if ((-e $fileneed) && (!-e $filecopy)) {
 	            $dirname =~  s!/[^/]+$!!;
   	            system("umask 2; mkdir -p -m 775 $dirname");
 	            system("cp $fileneed $filecopy");
-	            print "File copied to: $filecopy \n";
+	            $logger->info( "File copied to: $filecopy");
                  }
 	      }
 	   }
@@ -257,7 +256,7 @@ EOF
         else {
            if (($checkopt)  && ($fileneed =~ m/.*(\w)+.*/)) {
 	      if (! -e $fileneed) {
-		 print "File status unknown: $fileneed \n";
+		 $logger->info( "File status unknown: $fileneed ");
               }
            }
         }
@@ -287,7 +286,7 @@ sub linktarget($) {
 sub dataexport($$) {
     $_[0] =~ m!(.*)/(.*)!;                             # Stores directory containing file in $1.
     my $dir = $1;
-    print "export $_[1] $_[0] ..... " ;
+    $logger->info( "export $_[1] $_[0] ..... " );
     my $listing = `svn ls $_[1]`;
     if ($2 and $listing =~ /^$2\b/) {                  # Check if input is a file or directory (links treated as files).
 	unless (-e $dir) {                             # Make containing directory unless it already exists.
@@ -307,5 +306,5 @@ sub dataexport($$) {
 	system("cksum $_[0] >>$checksumfile");
 	chmod 0775, $checksumfile;
     }
-    print "success\n" if (-e $_[0]);
+    $logger->info( "success") if (-e $_[0]);
 }

--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -91,13 +91,11 @@ my $perl5lib = "$CIMEROOT/utils/perl5lib";
 push(@INC, $perl5lib);
 require Module::ModuleLoader;
 require Log::Log4perl;
-
 my $level = Log::Log4perl::Level::to_priority($opts{loglevel});
 Log::Log4perl->easy_init({level=>$level,
 			  layout=>'%m%n'});
 
-$logger = Log::Log4perl::get_logger();
-
+$logger = Log::Log4perl::get_logger("preview_namelists");
 
     
 
@@ -177,12 +175,12 @@ foreach my $model (@modelsorder) {
     my $file = "$dirs{$model}/buildnml";
     $logger->info( "     Calling $file ");
 #   This change requires a tag for all components, defering for the moment
-#    qx( $file -loglevel $opts{loglevel} $CASEROOT );
+#    system(" $file -loglevel $opts{loglevel} $CASEROOT ");
 
     if ($opts{loglevel} eq "DEBUG") {
-       qx(env PREVIEW_NML=1 $file $CASEROOT);
+       system("env PREVIEW_NML=1 $file $CASEROOT");
     } else {
-       qx($file $CASEROOT);
+       system("$file $CASEROOT");
     }
     if($? != 0){
 	$logger->logdie("$file failed $?");

--- a/utils/perl5lib/Module/ModuleLoader.pm
+++ b/utils/perl5lib/Module/ModuleLoader.pm
@@ -504,8 +504,15 @@ sub loadModuleModules()
          if($envvalue =~ /^\$/)
          {
 	     $envvalue =~ s/\$//g;
-	     $ENV{$key} = $ENV{$envvalue};
-	     $logger->info("setting environment variable $key=$ENV{$envvalue}");
+	     if(defined $self->{$envvalue}){
+		 $ENV{$key} = $self->{$envvalue};
+		 $logger->info("setting environment variable $key=$self->{$envvalue}");
+	     }elsif(defined $ENV{$envvalue}){
+		 $ENV{$key} = $ENV{$envvalue};
+		 $logger->info("setting environment variable $key=$ENV{$envvalue}");
+	     }else{
+		 $logger->warn("No variable $envvalue found, not setting $key");
+	     }		 
          }
          else
          {


### PR DESCRIPTION
Fix Moduleloader message, fix logger issues

Currently modules are loaded several times in the course of a model build, on yellowstone we
are setting an environment variable MP_MPILIB to the internal value of MPILIB, but modules are
loaded before this internal variable is set and that was generating an error due to an undefined variable in perl.   Change this error to a warning.   In the course of this fix I noticed that not all logger messages were making it to stdout.   In particular messages from subprograms called with the qx command or with backtics were lost.  Changing these calls to system calls fixed this problem.   Finally I also converted 
the check_input_data script to use logger.  

Test suite: yellowstone driver prealpha suite
Test baseline: none
Test namelist changes: none
Test status: bit for bit

Fixes: #304 possibly #89 

Code review: 
