### PR TITLE
Fix issues with cpl metadata, ibm compiler and cesm log file

### DIFF
--- a/cime_config/cesm/machines/config_compilers.xml
+++ b/cime_config/cesm/machines/config_compilers.xml
@@ -105,7 +105,7 @@ for mct, etc.
   <FIXEDFLAGS>  -qsuffix=f=f -qfixed=132 </FIXEDFLAGS>
   <FREEFLAGS> -qsuffix=f=f90:cpp=F90  </FREEFLAGS>
   <FFLAGS> -g -qfullpath -qmaxmem=-1 </FFLAGS>
-  <ADD_FFLAGS DEBUG="FALSE"> -O2 -qstrict -Q </ADD_FFLAGS>
+  <ADD_FFLAGS DEBUG="FALSE"> -O2 -qstrict -qinline=auto </ADD_FFLAGS>
   <ADD_CFLAGS DEBUG="FALSE"> -O3  </ADD_CFLAGS>
   <ADD_FFLAGS compile_threaded="true"> -qsmp=omp </ADD_FFLAGS>
   <ADD_CFLAGS compile_threaded="true"> -qsmp=omp </ADD_CFLAGS>
@@ -598,7 +598,7 @@ for mct, etc.
   <SCC> blrts_xlc </SCC>
   <MPICC> blrts_xlc </MPICC>
   <CFLAGS> -O3 -qstrict </CFLAGS>
-  <ADD_FFLAGS DEBUG="FALSE"> -O3 -qstrict -Q </ADD_FFLAGS>
+  <ADD_FFLAGS DEBUG="FALSE"> -O3 -qstrict -qinline=auto </ADD_FFLAGS>
   <ADD_FFLAGS DEBUG="TRUE"> -qinitauto=FF911299 -qflttrap=ov:zero:inv:en </ADD_FFLAGS>
   <MLIBS> -L/bgl/BlueLight/ppcfloor/bglsys/lib -lmpich.rts -lmsglayer.rts -lrts.rts -ldevices.rts </MLIBS>
   <ADD_CPPDEFS> -DLINUX -DnoI8 </ADD_CPPDEFS>
@@ -619,7 +619,7 @@ for mct, etc.
 
 <compiler COMPILER="ibm" OS="BGQ">
   <FFLAGS> -g -qfullpath -qmaxmem=-1 -qspillsize=2500 -qextname=flush </FFLAGS>
-  <ADD_FFLAGS DEBUG="FALSE"> -O3 -qstrict -Q </ADD_FFLAGS>
+  <ADD_FFLAGS DEBUG="FALSE"> -O3 -qstrict -qinline=auto </ADD_FFLAGS>
   <ADD_FFLAGS DEBUG="FALSE" compile_threaded="true"> -qsmp=omp </ADD_FFLAGS>
   <ADD_FFLAGS DEBUG="TRUE" compile_threaded="true"> -qsmp=omp:noopt </ADD_FFLAGS>
   <ADD_CPPDEFS> -DLINUX  </ADD_CPPDEFS>

--- a/cime_config/cesm/machines/template.cesmrun
+++ b/cime_config/cesm/machines/template.cesmrun
@@ -446,7 +446,7 @@ sub postRun()
         }
 
         $logger->debug("lid: $LID");
-	foreach my $comp (qw(atm cpl ocn wav glc ice rof lnd)){
+	foreach my $comp (qw(atm cpl ocn wav glc ice rof lnd cesm)){
 	    disposeLog($config{RUNDIR},$config{CASEROOT}, $comp ,$LID,$config{LOGDIR});
 	}
     }

--- a/utils/perl5lib/Config/ConfigCase.pm
+++ b/utils/perl5lib/Config/ConfigCase.pm
@@ -121,9 +121,8 @@ sub add_config_variables
                     if($val_node->hasAttributes()){		 
                     my @att = $val_node->attributes();
 		    foreach my $attstr (@att){
-			$attstr =~ /(\w+)=\"(.*)\"/;
-	                my $att = $1;
-	                my $att_val = $2;
+			my $att = $attstr->nodeName();
+			my $att_val = $attstr->getValue();
 			my $val =  $val_node->textContent();		
 			$val =~ s/\$MODEL/$model/;
 			$val =~ s/\$CIMEROOT/$cimeroot/;


### PR DESCRIPTION
cpl metadata for variables in a colon seperated list needed to be
handled differently.   metadata_set now handles that correctly.
ibm compiler -Q is now -qinline=auto
cesm log file was not being compressed and copied to case/logs

Test suite:  compared cpl metadata before and after for several cases
Test baseline: n/a
Test namelist changes: n/a
Test status: bit for bit

Fixes:

Code review:
