### PR TITLE
Send topo field from datm, using a new topo stream

### DIFF
--- a/components/data_comps/datm/bld/build-namelist
+++ b/components/data_comps/datm/bld/build-namelist
@@ -417,7 +417,9 @@ if ($DATM_PRESAERO ne "none") {
     } else {
 	push (@streams, "presaero.$DATM_PRESAERO");
     }
-}
+ }
+# TODO(wjs, 2015-11-30) Put this in a conditional, as is done for the presaero stream
+push (@streams, "topo.observed");
 
 if ($DATM_CO2_TSERIES ne "none") {
     push (@streams, "co2tseries.$DATM_CO2_TSERIES");

--- a/components/data_comps/datm/bld/build-namelist
+++ b/components/data_comps/datm/bld/build-namelist
@@ -50,7 +50,8 @@ Note: The precedence for setting the values of namelist variables is (highest to
 
 NOTE: The following xml variables are REQUIRED (they are already set by scripts in the env_*.xml files)
          RUN_TYPE    DIN_LOC_ROOT  ATM_DOMAIN_FILE   ATM_DOMAIN_PATH
-	 DATM_MODE   DATM_PRESAERO DATM_CO2_TSERIES  ATM_GRID          GRID                     
+	 DATM_MODE   DATM_PRESAERO DATM_TOPO         DATM_CO2_TSERIES
+         ATM_GRID    GRID                     
 EOF
 }
 
@@ -347,7 +348,8 @@ foreach my $attr (keys %xmlvars) {
     $xmlvars{$attr} = SetupTools::expand_xml_var($xmlvars{$attr}, \%xmlvars); 
 }
 foreach my $var ( "RUN_TYPE", "DIN_LOC_ROOT", "ATM_DOMAIN_FILE", "ATM_DOMAIN_PATH", 
-		  "DATM_MODE", "DATM_PRESAERO", "DATM_CO2_TSERIES", "ATM_GRID", "GRID" ) {
+		  "DATM_MODE", "DATM_PRESAERO", "DATM_TOPO", "DATM_CO2_TSERIES",
+                  "ATM_GRID", "GRID" ) {
     if ( $print > 1 ) { print "$var = $xmlvars{$var}\n"; }
     if ( ! defined($xmlvars{$var})  || $xmlvars{$var} =~ /^(UNSET|)$/ ) {
 	die "** $ProgName - $var is NOT set  ** \n"
@@ -360,6 +362,7 @@ my $ATM_DOMAIN_FILE = $xmlvars{'ATM_DOMAIN_FILE'};
 my $ATM_DOMAIN_PATH = $xmlvars{'ATM_DOMAIN_PATH'};
 my $DATM_MODE       = $xmlvars{'DATM_MODE'};   
 my $DATM_PRESAERO   = $xmlvars{'DATM_PRESAERO'};    
+my $DATM_TOPO       = $xmlvars{'DATM_TOPO'};    
 my $DATM_CO2_TSERIES= $xmlvars{'DATM_CO2_TSERIES'};
 my $ATM_GRID        = $xmlvars{'ATM_GRID'};    
 my $GRID            = $xmlvars{'GRID'};     
@@ -368,6 +371,9 @@ my $CLM_USRDAT_NAME = $xmlvars{'CLM_USRDAT_NAME'};
 # Validate some of the env values.
 if ( $DATM_MODE =~ /CLM/ && $DATM_PRESAERO eq "none" ) {
    die "${nm}:: A DATM_MODE for CLM is incompatible with DATM_PRESAERO=none\n";
+}
+if ( $DATM_MODE =~ /CLM/ && $DATM_TOPO eq "none" ) {
+   die "${nm}:: A DATM_MODE for CLM is incompatible with DATM_TOPO=none\n";
 }
 
 if ( $GRID eq "CLM_USRDAT" && $CLM_USRDAT_NAME =~ /^(UNSET|)$/ ) {
@@ -392,6 +398,7 @@ $nl->set_variable_value( $group, $var, "\'$xmlvars{$var}\'" );
 
 if ($print>=1) { print "  datm mode is $DATM_MODE \n"; }
 if ($print>=1) { print "  datm presaero mode is $DATM_PRESAERO \n"; }
+if ($print>=1) { print "  datm topo mode is $DATM_TOPO \n"; }
 if ($print>=1) { print "  datm model grid is $GRID \n"; }
 if ($print>=1) { print "  datm atm   grid is $ATM_GRID \n" };
 
@@ -418,8 +425,9 @@ if ($DATM_PRESAERO ne "none") {
 	push (@streams, "presaero.$DATM_PRESAERO");
     }
  }
-# TODO(wjs, 2015-11-30) Put this in a conditional, as is done for the presaero stream
-push (@streams, "topo.observed");
+if ($DATM_TOPO ne "none") {
+   push (@streams, "topo.$DATM_TOPO");
+}
 
 if ($DATM_CO2_TSERIES ne "none") {
     push (@streams, "co2tseries.$DATM_CO2_TSERIES");

--- a/components/data_comps/datm/bld/namelist_files/namelist_defaults_datm.xml
+++ b/components/data_comps/datm/bld/namelist_files/namelist_defaults_datm.xml
@@ -45,7 +45,8 @@ Currently the following streams are supported (term definitions precede the stre
     CORE2_NYF       = CORE2 normal year forcing (for forcing POP and CICE)
     CORE2_IAF       = CORE2 intra-annual year forcing (for forcing POP and CICE)
     CPLHIST3HrWx    = Run with CESM 3-hourly coupler history output
-    presaero        = Prescribed aerosol forcing 
+    presaero        = Prescribed aerosol forcing
+    topo            = Surface topography
     co2tseries      = Time series of prescribed CO2 forcing
     Anomaly.Forcing = Time series of correction terms
     BC              = Bias Correction for a stream to a given set of observations
@@ -135,6 +136,8 @@ Currently the following streams are supported (term definitions precede the stre
     presaero.rcp4.5
     presaero.rcp6.0
     presaero.rcp8.5
+
+    topo.observed
 
     WW3
 
@@ -2217,6 +2220,35 @@ af.rlds.ccsm4.rcp45.2006-2300.nc
 <strm_domfil     stream="presaero.rcp8.5">aerosoldep_rcp8.5_monthly_1849-2104_1.9x2.5_c100201.nc</strm_domfil>
 <strm_datdir     stream="presaero.rcp8.5">$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/aero</strm_datdir>
 <strm_datfil     stream="presaero.rcp8.5">aerosoldep_rcp8.5_monthly_1849-2104_1.9x2.5_c100201.nc</strm_datfil>
+
+<!-- =========================================  -->
+<!-- Surface topographic height                 -->
+<!-- =========================================  -->
+
+<strm_offset   stream="topo.observed">0</strm_offset>
+<!-- tintalgo is arbitrary here since we only have one time slice; however, note
+     that setting this to 'linear' gives roundoff-level differences between time
+     steps, which is undesirable unless we truly want linear interpolation
+     between multiple input values -->
+<strm_tintalgo stream="topo.observed">lower</strm_tintalgo>
+<strm_domvar   stream="topo.observed">
+   time   time
+   LONGXY lon
+   LATIXY lat
+   area   area
+   mask   mask
+</strm_domvar>
+<strm_datvar stream="topo.observed">
+   TOPO topo
+</strm_datvar>
+
+<strm_year_start stream="topo.observed">1</strm_year_start>
+<strm_year_end   stream="topo.observed">1</strm_year_end>
+<strm_year_align stream="topo.observed">1</strm_year_align>
+<strm_domdir     stream="topo.observed">$DIN_LOC_ROOT/atm/datm7/topo_forcing</strm_domdir>
+<strm_domfil     stream="topo.observed">topodata_0.9x1.25_USGS_070110_stream_c151201.nc</strm_domfil>
+<strm_datdir     stream="topo.observed">$DIN_LOC_ROOT/atm/datm7/topo_forcing</strm_datdir>
+<strm_datfil     stream="topo.observed">topodata_0.9x1.25_USGS_070110_stream_c151201.nc</strm_datfil>
 
 <!-- =========================================  -->
 <!-- Other stream variables                     -->

--- a/components/data_comps/datm/cime_config/config_component.xml
+++ b/components/data_comps/datm/cime_config/config_component.xml
@@ -58,6 +58,20 @@
     <desc>DATM prescribed aerosol forcing</desc>
   </entry>
 
+  <entry id="DATM_TOPO">
+     <type>char</type>
+     <valid_values>none,observed</valid_values>
+     <default_value>observed</default_value>
+     <values>
+        <!-- Only needed for compsets with active land; for other compsets, turn it off -->
+        <value compset="_SLND">none</value>
+        <value compset="_DLND">none</value>
+     </values>
+    <group>run_component_datm</group>
+    <file>env_run.xml</file>
+    <desc>DATM surface topography forcing</desc>
+  </entry>
+
   <entry id="DATM_CO2_TSERIES">
     <type>char</type>
     <valid_values>none,20tr,rcp2.6,rcp4.5,rcp6.0,rcp8.5</valid_values>

--- a/components/data_comps/datm/datm_comp_mod.F90
+++ b/components/data_comps/datm/datm_comp_mod.F90
@@ -96,7 +96,7 @@ module datm_comp_mod
   data   dTarc      / 0.49_R8, 0.06_R8,-0.73_R8,  -0.89_R8,-0.77_R8,-1.02_R8, &
   &                  -1.99_R8,-0.91_R8, 1.72_R8,   2.30_R8, 1.81_R8, 1.06_R8/
 
-  integer(IN) :: kz,ku,kv,ktbot,kptem,kshum,kdens,kpbot,kpslv,klwdn
+  integer(IN) :: kz,ktopo,ku,kv,ktbot,kptem,kshum,kdens,kpbot,kpslv,klwdn
   integer(IN) :: krc,krl,ksc,ksl,kswndr,kswndf,kswvdr,kswvdf,kswnet,kco2p,kco2d
   integer(IN) :: kbid,kbod,kbiw,koid,kood,koiw,kdw1,kdw2,kdw3,kdw4,kdd1,kdd2,kdd3,kdd4
   integer(IN) :: kanidr,kanidf,kavsdr,kavsdf
@@ -120,10 +120,11 @@ module datm_comp_mod
   !
   ! for anomaly forcing
   !
-  integer(IN),parameter :: ktrans  = 65
+  integer(IN),parameter :: ktrans  = 66
 
   character(16),parameter  :: avofld(1:ktrans) = &
-       (/"Sa_z            ","Sa_u            ","Sa_v            ","Sa_tbot         ", &
+       (/"Sa_z            ","Sa_topo         ", &
+         "Sa_u            ","Sa_v            ","Sa_tbot         ", &
          "Sa_ptem         ","Sa_shum         ","Sa_dens         ","Sa_pbot         ", &
          "Sa_pslv         ","Faxa_lwdn       ","Faxa_rainc      ","Faxa_rainl      ", &
          "Faxa_snowc      ","Faxa_snowl      ","Faxa_swndr      ","Faxa_swvdr      ", &
@@ -147,7 +148,8 @@ module datm_comp_mod
        /)
 
   character(16),parameter  :: avifld(1:ktrans) = &
-       (/"z               ","u               ","v               ","tbot            ", &
+       (/"z               ","topo            ", &
+         "u               ","v               ","tbot            ", &
          "ptem            ","shum            ","dens            ","pbot            ", &
          "pslv            ","lwdn            ","rainc           ","rainl           ", &
          "snowc           ","snowl           ","swndr           ","swvdr           ", &
@@ -171,6 +173,10 @@ module datm_comp_mod
   ! add stream for anomaly forcing
   integer(IN),parameter :: ktranss = 28
 
+  ! The stofld and stifld lists are used for fields that are read but not passed to the
+  ! coupler (e.g., they are used to compute fields that are passed to the coupler), and
+  ! other fields used in calculations. Fields that are simply read and passed directly to
+  ! the coupler do not need to be in these lists.
   character(16),parameter  :: stofld(1:ktranss) = &
        (/"strm_tbot       ","strm_wind       ","strm_z          ","strm_pbot       ", &
          "strm_shum       ","strm_tdew       ","strm_rh         ","strm_lwdn       ", &
@@ -540,6 +546,7 @@ subroutine datm_comp_init( EClock, cdata, x2a, a2x, NLFilename )
     call mct_aVect_zero(a2x)
 
     kz    = mct_aVect_indexRA(a2x,'Sa_z')
+    ktopo = mct_aVect_indexRA(a2x,'Sa_topo')
     ku    = mct_aVect_indexRA(a2x,'Sa_u')
     kv    = mct_aVect_indexRA(a2x,'Sa_v')
     ktbot = mct_aVect_indexRA(a2x,'Sa_tbot')


### PR DESCRIPTION
CLM will soon require a topo field from atm. An earlier cime change
added this field, and CAM has already been updated to send this
field. This PR adds datm capability to send this field, using a new topo
stream.

This topo stream is only enabled when running with an active land model
(vaguely similar to what is done for the presaero stream).

For now, the topo dataset that is used is the same as what CLM had been
using with its old mechanism (when running at f09), which is based on an
old version of CAM's f09 topography. Soon, I will change this to use
actual, observed topography, rather than this file in which topography
is smoothed for the sake of CAM.

Test suite: yellowstone drv prealpha
Test baseline: cesm1_5_alpha03e
Test namelist changes: none
Test status: bit for bit

Also ran two other tests:

(1) SMS.f09_g16_gl5.IG1850CLM50.yellowstone_intel.clm-glcMEC with
    comparison against CLM trunk (done with
    https://svn-ccsm-models.cgd.ucar.edu/clm2/branch_tags/topo_from_atm_tags/topo_from_atm_n01_clm4_5_6_r157,
    and using a version of cime branch that was based off of the tag
    currently in the CLM trunk): passes and bit-for-bit. Note that other
    resolutions (f19, T31) are NOT expected to be bit for bit. This
    confirms that answers are maintained for CLM at f09 with topo coming
    from datm rather than CLM's own file.

(2) ERS.T62_g16.C.yellowstone_intel.pop-default with comparison against
    cesm1_5_alpha03e: passes and bit for bit. This confirms that I
    haven't broken other datm modes.

Fixes: None

User interface changes?: No

Code review: None yet
