### PR TITLE
Add rtm and mosart as components to test system.

### DIFF
--- a/cime_config/cesm/config_files.xml
+++ b/cime_config/cesm/config_files.xml
@@ -98,6 +98,8 @@
       <value component="clm"      >$SRCROOT/components/clm/cime_config/testdefs/testlist_clm.xml</value>
       <value component="cice"     >$SRCROOT/components/cice/cime_config/testdefs/testlist_cice.xml</value>
       <value component="pop"      >$SRCROOT/components/pop/cime_config/testdefs/testlist_pop.xml</value>
+      <value component="rtm"      >$SRCROOT/components/rtm/cime_config/testdefs/testlist_rtm.xml</value>
+      <value component="mosart"   >$SRCROOT/components/mosart/cime_config/testdefs/testlist_mosart.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>

--- a/scripts/Tools/component_compare_move.sh
+++ b/scripts/Tools/component_compare_move.sh
@@ -112,7 +112,7 @@ if [ -n "$add_iop" ]; then
 fi
 
 cd $rundir
-models=(cam cice clm2 pop cism cpl)
+models=(cam cice clm2 pop cism cpl rtm mosart)
 for model in ${models[*]}; do
     
     if [ "$model" = "cism" ]; then
@@ -127,6 +127,10 @@ for model in ${models[*]}; do
 	extensions=(h0 h1 h2 h3 h4 h5 h6 h7)
     elif [ "$model" = "pop" ]; then
 	extensions=(h)
+    elif [ "$model" = "rtm" ]; then
+	extensions=(h0 h1 h2)
+    elif [ "$model" = "mosart" ]; then
+	extensions=(h0 h1 h2)
     fi
 
     #------------------------------------------------------------------

--- a/scripts/Tools/component_compare_test.sh
+++ b/scripts/Tools/component_compare_test.sh
@@ -190,7 +190,7 @@ cprnc_exe=`./xmlquery CCSM_CPRNC -value`
 cd $rundir
 overall_status='PASS'
 
-models=(cam cice clm2 pop cism cpl)
+models=(cam cice clm2 pop cism cpl rtm mosart)
 for model in ${models[*]}; do
     
     if [ "$model" = "cism" ]; then
@@ -205,6 +205,10 @@ for model in ${models[*]}; do
 	extensions=(h0 h1 h2 h3 h4 h5 h6 h7 h8 h9 hs)
     elif [ "$model" = "pop" ]; then
 	extensions=(h)
+    elif [ "$model" = "rtm" ]; then
+	extensions=(h0 h1 h2)
+    elif [ "$model" = "mosart" ]; then
+	extensions=(h0 h1 h2)
     fi
 
     #------------------------------------------------------------------

--- a/scripts/Tools/component_compgen_baseline.sh
+++ b/scripts/Tools/component_compgen_baseline.sh
@@ -217,7 +217,7 @@ fi
 overall_compare_status='PASS'
 overall_generate_status='PASS'
 
-models=( cam cice cism clm2 cpl pop )
+models=( cam cice cism clm2 cpl pop rtm mosart)
 for model in ${models[*]}; do
     if [ "$model" = "cism" ]; then
 	extensions=(h)
@@ -231,6 +231,10 @@ for model in ${models[*]}; do
 	extensions=(h0 h1 h2 h3 h4 h5 h6 h7)
     elif [ "$model" = "pop" ]; then
 	extensions=(h)
+    elif [ "$model" = "rtm" ]; then
+	extensions=(h0 h1 h2)
+    elif [ "$model" = "mosart" ]; then
+	extensions=(h0 h1 h2)
     fi
 
     #------------------------------------------------------------------


### PR DESCRIPTION
Update the test system to include rtm and mosart as known
components. Adds rtm and mosart as components in history comparison
scripts with history file extensions. Include rtm and mosart in list
of known testlist_*.xml files.

Note: This does NOT modify the all active tests for alpha and beta
 tests to include rtm and mosart history output. 

Test suite: clm4_5_7_r162 base, test suites clm_short45, clm_short50, mosart and rtm
Test baseline: clm4_5_7_r162 for clm_short*. mosart and rtm suites do not have baselines.
Test namelist changes: none
Test status: bit for bit

Code reviews: none
