### PR TITLE
update st_archive, supporting files and XML schemas

### DIFF
--- a/cime_config/cesm/archive.xml
+++ b/cime_config/cesm/archive.xml
@@ -2,87 +2,87 @@
   <comp_archive_spec name="cam">
     <rootdir>atm</rootdir>
     <files>
-      <file_extension suffix=".log\..*">
+      <file_extension regex_suffix=".log\..*">
 	<subdir>logs</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".r\..*">
+      <file_extension regex_suffix=".r\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rs\..*">
+      <file_extension regex_suffix=".rs\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".ra\..*">
+      <file_extension regex_suffix=".ra\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh0\..*">
+      <file_extension regex_suffix=".rh0\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh1\..*">
+      <file_extension regex_suffix=".rh1\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh2\..*">
+      <file_extension regex_suffix=".rh2\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh3\..*">
+      <file_extension regex_suffix=".rh3\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh4\..*">
+      <file_extension regex_suffix=".rh4\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh5\..*">
+      <file_extension regex_suffix=".rh5\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".i\..*">
+      <file_extension regex_suffix=".i\..*">
 	<subdir>init</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h0\.[\w\-]*\.nc$">      
+      <file_extension regex_suffix=".h0\.[\w\-]*\.nc$">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h1\.[\w\-]*\.nc$">      
+      <file_extension regex_suffix=".h1\.[\w\-]*\.nc$">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h2\..*">      
+      <file_extension regex_suffix=".h2\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h3\..*">      
+      <file_extension regex_suffix=".h3\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h4\..*">      
+      <file_extension regex_suffix=".h4\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h5\..*">      
+      <file_extension regex_suffix=".h5\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h6\..*">      
+      <file_extension regex_suffix=".h6\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h7\..*">      
+      <file_extension regex_suffix=".h7\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h8\..*">      
+      <file_extension regex_suffix=".h8\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".hs\..*">      
+      <file_extension regex_suffix=".hs\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
@@ -92,15 +92,15 @@
   <comp_archive_spec name="datm">
     <rootdir>atm</rootdir>
     <files>
-      <file_extension suffix=".r\..*">
+      <file_extension regex_suffix=".r\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rs\..*">
+      <file_extension regex_suffix=".rs\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h\..*">      
+      <file_extension regex_suffix=".h\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
@@ -110,67 +110,67 @@
   <comp_archive_spec name="clm[0-9]+">
     <rootdir>lnd</rootdir>
     <files>
-      <file_extension suffix=".log\..*">
+      <file_extension regex_suffix=".log\..*">
 	<subdir>logs</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".r\..*">
+      <file_extension regex_suffix=".r\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh0\..*">
+      <file_extension regex_suffix=".rh0\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh1\..*">
+      <file_extension regex_suffix=".rh1\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh2\..*">
+      <file_extension regex_suffix=".rh2\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh3\..*">
+      <file_extension regex_suffix=".rh3\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh4\..*">
+      <file_extension regex_suffix=".rh4\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh5\..*">
+      <file_extension regex_suffix=".rh5\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".i\..*">
+      <file_extension regex_suffix=".i\..*">
 	<subdir>init</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h0\.[\w\-]*\.nc$">      
+      <file_extension regex_suffix=".h0\.[\w\-]*\.nc$">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h1\..*">      
+      <file_extension regex_suffix=".h1\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h2\..*">      
+      <file_extension regex_suffix=".h2\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h3\..*">      
+      <file_extension regex_suffix=".h3\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h4\..*">      
+      <file_extension regex_suffix=".h4\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h5\..*">      
+      <file_extension regex_suffix=".h5\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".hv\..*">      
+      <file_extension regex_suffix=".hv\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
@@ -180,15 +180,15 @@
   <comp_archive_spec name="dlnd">
     <rootdir>lnd</rootdir>
     <files>
-      <file_extension suffix=".r\..*">
+      <file_extension regex_suffix=".r\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rs\..*">
+      <file_extension regex_suffix=".rs\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h\..*">      
+      <file_extension regex_suffix=".h\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
@@ -198,43 +198,43 @@
   <comp_archive_spec name="rtm">
     <rootdir>rof</rootdir>
     <files>
-      <file_extension suffix=".log\..*">
+      <file_extension regex_suffix=".log\..*">
 	<subdir>logs</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".r\..*">
+      <file_extension regex_suffix=".r\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh0\..*">
+      <file_extension regex_suffix=".rh0\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh1\..*">
+      <file_extension regex_suffix=".rh1\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh2\..*">
+      <file_extension regex_suffix=".rh2\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh3\..*">
+      <file_extension regex_suffix=".rh3\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h0\..*">      
+      <file_extension regex_suffix=".h0\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h1\..*">      
+      <file_extension regex_suffix=".h1\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h2\..*">      
+      <file_extension regex_suffix=".h2\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h3\..*">      
+      <file_extension regex_suffix=".h3\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
@@ -244,43 +244,43 @@
   <comp_archive_spec name="mosart">
     <rootdir>rof</rootdir>
     <files>
-      <file_extension suffix=".log\..*">
+      <file_extension regex_suffix=".log\..*">
 	<subdir>logs</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".r\..*">
+      <file_extension regex_suffix=".r\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh0\..*">
+      <file_extension regex_suffix=".rh0\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh1\..*">
+      <file_extension regex_suffix=".rh1\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh2\..*">
+      <file_extension regex_suffix=".rh2\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh3\..*">
+      <file_extension regex_suffix=".rh3\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h0\..*">      
+      <file_extension regex_suffix=".h0\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h1\..*">      
+      <file_extension regex_suffix=".h1\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h2\..*">      
+      <file_extension regex_suffix=".h2\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h3\..*">      
+      <file_extension regex_suffix=".h3\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
@@ -290,15 +290,15 @@
   <comp_archive_spec name="drof">
     <rootdir>rof</rootdir>
     <files>
-      <file_extension suffix=".r\..*">
+      <file_extension regex_suffix=".r\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rs\..*">
+      <file_extension regex_suffix=".rs\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h\..*">      
+      <file_extension regex_suffix=".h\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
@@ -308,19 +308,19 @@
   <comp_archive_spec name="cice">
     <rootdir>ice</rootdir>
     <files>
-      <file_extension suffix=".log\..*">
+      <file_extension regex_suffix=".log\..*">
 	<subdir>logs</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".r\.\w+">
+      <file_extension regex_suffix=".r\.\w+">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".i\..*">
+      <file_extension regex_suffix=".i\..*">
 	<subdir>init</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h\.[\w\-]*\.nc$">      
+      <file_extension regex_suffix=".h\.[\w\-]*\.nc$">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
@@ -330,15 +330,15 @@
   <comp_archive_spec name="dice">
     <rootdir>ice</rootdir>
     <files>
-      <file_extension suffix=".r\..*">
+      <file_extension regex_suffix=".r\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rs\..*">
+      <file_extension regex_suffix=".rs\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h\..*">      
+      <file_extension regex_suffix=".h\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
@@ -348,67 +348,67 @@
   <comp_archive_spec name="pop">
     <rootdir>ocn</rootdir>
     <files>
-      <file_extension suffix=".log\..*">
+      <file_extension regex_suffix=".log\..*">
 	<subdir>logs</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".r\..*\.hdr">
+      <file_extension regex_suffix=".r\..*\.hdr">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".r\.[0-9|-]+\.nc">
+      <file_extension regex_suffix=".r\.[0-9|-]+\.nc">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".r\.[0-9|-]+[^\.nc]">
+      <file_extension regex_suffix=".r\.[0-9|-]+[^\.nc]">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh.ecosys\.\w+\.hdr">
+      <file_extension regex_suffix=".rh.ecosys\.\w+\.hdr">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh.ecosys\.\w+\.nc">
+      <file_extension regex_suffix=".rh.ecosys\.\w+\.nc">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh.ecosys\.[0-9|-]+[^\.nc]">
+      <file_extension regex_suffix=".rh.ecosys\.[0-9|-]+[^\.nc]">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh\..*\.hdr">
+      <file_extension regex_suffix=".rh\..*\.hdr">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh\.[0-9|-]+\.nc">
+      <file_extension regex_suffix=".rh\.[0-9|-]+\.nc">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rh\.[0-9|-]+[^\.nc]">
+      <file_extension regex_suffix=".rh\.[0-9|-]+[^\.nc]">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".ro\..*">
+      <file_extension regex_suffix=".ro\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".d\w*">
+      <file_extension regex_suffix=".d\w*">
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h.\d{4}-\d{2}\..*">      
+      <file_extension regex_suffix=".h.\d{4}-\d{2}\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h.nday1\..*">      
+      <file_extension regex_suffix=".h.nday1\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h.nyear1\..*">      
+      <file_extension regex_suffix=".h.nyear1\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h\.[\w\-\.]*\.nc$">      
+      <file_extension regex_suffix=".h\.[\w\-\.]*\.nc$">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
@@ -418,15 +418,15 @@
   <comp_archive_spec name="docn">
     <rootdir>ocn</rootdir>
     <files>
-      <file_extension suffix=".r\..*">
+      <file_extension regex_suffix=".r\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rs\..*">
+      <file_extension regex_suffix=".rs\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h\..*">      
+      <file_extension regex_suffix=".h\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
@@ -436,23 +436,23 @@
   <comp_archive_spec name="cism">
     <rootdir>glc</rootdir>
     <files>
-      <file_extension suffix=".log\..*">
+      <file_extension regex_suffix=".log\..*">
 	<subdir>logs</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".r.[0-9]*">
+      <file_extension regex_suffix=".r.[0-9]*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".r\.\w+">
+      <file_extension regex_suffix=".r\.\w+">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".i\..*">
+      <file_extension regex_suffix=".i\..*">
 	<subdir>init</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h*">      
+      <file_extension regex_suffix=".h*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
@@ -462,19 +462,19 @@
   <comp_archive_spec name="ww3">
     <rootdir>wav</rootdir>
     <files>
-      <file_extension suffix=".log\..*">
+      <file_extension regex_suffix=".log\..*">
 	<subdir>logs</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".r.[0-9]*">
+      <file_extension regex_suffix=".r.[0-9]*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".i\..*">
+      <file_extension regex_suffix=".i\..*">
 	<subdir>init</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h\..*">      
+      <file_extension regex_suffix=".h\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
@@ -484,15 +484,15 @@
   <comp_archive_spec name="dwav">
     <rootdir>wav</rootdir>
     <files>
-      <file_extension suffix=".r\..*">
+      <file_extension regex_suffix=".r\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".rs\..*">
+      <file_extension regex_suffix=".rs\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h\..*">      
+      <file_extension regex_suffix=".h\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
@@ -502,55 +502,55 @@
   <comp_archive_spec name="dart"> 
     <rootdir>dart</rootdir>
     <files>
-      <file_extension suffix="\w*dart_log\..*">
+      <file_extension regex_suffix="\w*dart_log\..*">
 	<subdir>logs</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix="\w*True_State\..*\.nc">
+      <file_extension regex_suffix="\w*True_State\..*\.nc">
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix="\w*Prior_Diag\..*.nc">
+      <file_extension regex_suffix="\w*Prior_Diag\..*.nc">
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix="\w*Posterior_Diag\..*.nc">
+      <file_extension regex_suffix="\w*Posterior_Diag\..*.nc">
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix="\w*obs_seq\..*.out">
+      <file_extension regex_suffix="\w*obs_seq\..*.out">
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix="\w*obs_seq\..*.final">
+      <file_extension regex_suffix="\w*obs_seq\..*.final">
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix="\w*obs_seq\..*.perfect">
+      <file_extension regex_suffix="\w*obs_seq\..*.perfect">
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix="cam_\w*pr\w*inflate_restart\w*">
+      <file_extension regex_suffix="cam_\w*pr\w*inflate_restart\w*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix="cam_\w*po\w*inflate_restart\w*">
+      <file_extension regex_suffix="cam_\w*po\w*inflate_restart\w*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix="clm_\w*pr\w*inflate_restart\w*">
+      <file_extension regex_suffix="clm_\w*pr\w*inflate_restart\w*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix="clm_\w*po\w*inflate_restart\w*">
+      <file_extension regex_suffix="clm_\w*po\w*inflate_restart\w*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix="pop_\w*pr\w*inflate_restart\w*">
+      <file_extension regex_suffix="pop_\w*pr\w*inflate_restart\w*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix="pop_\w*po\w*inflate_restart\w*">
+      <file_extension regex_suffix="pop_\w*po\w*inflate_restart\w*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
@@ -560,19 +560,19 @@
   <comp_archive_spec name="cpl"> 
     <rootdir>cpl</rootdir>
     <files>
-      <file_extension suffix="cpl.log\..*">
+      <file_extension regex_suffix="cpl.log\..*">
 	<subdir>logs</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".r\..*">
+      <file_extension regex_suffix=".r\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix="cesm*.log\..*">
+      <file_extension regex_suffix="cesm*.log\..*">
 	<subdir>logs</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>
-      <file_extension suffix=".h\w*">
+      <file_extension regex_suffix=".h\w*">
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
       </file_extension>

--- a/cime_config/cesm/machines/template.st_archive
+++ b/cime_config/cesm/machines/template.st_archive
@@ -47,7 +47,7 @@ if(-e $testlog){
     close(TL);
 }
 $logger->info("st_archive starting");
-system("./st_archive >> stArchiveStatus 2>&1");
+system("$config{CASEROOT}/st_archive >> stArchiveStatus 2>&1");
 if(-e $testlog){
     open(TL,">>$testlog");
     print TL "st_archive complete\n";

--- a/cime_config/xml_schemas/archive.xsd
+++ b/cime_config/xml_schemas/archive.xsd
@@ -25,7 +25,7 @@
 				<xs:element name="subdir" type="xs:string"/>
 				<xs:element name="keep_last_in_rundir" type="xs:string"/>
 			      </xs:sequence>
-			      <xs:attribute name="suffix" type="xs:string" use="required"/>
+			      <xs:attribute name="regex_suffix" type="xs:string" use="required"/>
 			    </xs:complexType>
 			  </xs:element>
 

--- a/cime_config/xml_schemas/cimeteststatus.xsd
+++ b/cime_config/xml_schemas/cimeteststatus.xsd
@@ -28,7 +28,7 @@
   <xs:element name="section">
     <xs:complexType>
       <xs:sequence>
-	<xs:element ref="key" maxOccurs="unbounded"/>
+	<xs:element ref="key" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute ref="name" use="required"/>
     </xs:complexType>

--- a/scripts/Tools/st_archive
+++ b/scripts/Tools/st_archive
@@ -20,7 +20,7 @@ use File::Find;
 use File::stat;
 use File::Glob;
 
-# the st_archive is run in the CASEROOT/Tools
+# the st_archive is run in the CASEROOT
 my $cimeroot  = `./xmlquery CIMEROOT  -value`;
 my @dirs = ("$cimeroot/utils/perl5lib" );
 
@@ -130,14 +130,14 @@ ENV_ARCHIVE.XML SCHEMA AND DOCUMENT TYPE DEFINITION (DTD)
         $\DOUT_S_ROOT location.  These may not correspond to the model
         component name.
 
-        <files> <file_extension suffix="[regular expression string]">
+        <files> <file_extension regex_suffix="[regular expression string]">
 	Perl regular expression specification for "globbing" filenames
 	for matching. Run the command "\$CASEROOT/st_archive -input"
 	command to see the list of valid suffices. If the suffix
-	begins with a "." then all files matching *.(suffix) are
+	begins with a "." then all files matching *.(regex_suffix) are
 	included in the globbing. If the suffix begins with a
 	character other than "." then all files matching exactly the
-	(suffix) are included in the globbing.
+	(regex_suffix) are included in the globbing.
 
             <subdir>[string] (logs|rest|hist|init|diag)</subdir> 
 	    subdirectory name to be created under the
@@ -195,7 +195,7 @@ OPTIONS
 
 
 EOF
-#" added per for emacs perl mode parsing
+#" added for emacs perl mode parsing
 
     $logger->info($usgstatement);
     exit(1);
@@ -297,9 +297,8 @@ The env_archive.xml brief XML tag schema:
 
     <comp_archive_spec name="[string:component name] (cpl|dart|cam\*|datm|clm\?|dlnd|rtm|cice|dice|pop|docn|cism|ww3|dwav)">
 	<rootdir>[string:root directory name after DOUT_S_ROOT.locked] (rest|cpl|dart|atm|lnd|rof|ice|ocn|glc|wav)</rootdir>
-        <multi_instance>[string: multi-instance support] (true|false)</multi_instance>
         <files>
-            <file_extension suffix="[string: perl regular expression for matching file suffix patterns"]>
+            <file_extension regex_suffix="[string: perl regular expression for matching file suffix patterns"]>
 	    <keep_last_in_rundir>[string: specify if the most recent copy of the matching file should be saved in the RUNDIR] (true|false)</keep_last_in_rundir> 
         </files>
     </comp_archive_spec>
@@ -336,12 +335,12 @@ EOF
 	my @files = $comp->findnodes('./files/file_extension');
         foreach my $file (@files) 
 	{
-	    my $suffix = $file->getAttribute('suffix');
+	    my $suffix = $file->getAttribute('regex_suffix');
 	    my $subdir = $file->findvalue('./subdir');
 	    my $keep_last_in_rundir = $file->findvalue('./keep_last_in_rundir');
 
 	    $logger->info("\n***** File extension specification");
-	    $logger->info("  suffix = $suffix");  
+	    $logger->info("  regex_suffix = $suffix");  
 	    $logger->info("  subdir = $config{'DOUT_S_ROOT'}/$config{'CASENAME'}$rootdir/$subdir");
 	    $logger->info("  keep_last_in_rundir = $keep_last_in_rundir");
 	}
@@ -488,14 +487,11 @@ sub moveFiles
 
 	if( $keep_last_in_rundir eq 'true' ) {
 #
-# copy the last file into the destination dir and the restdir
+# copy the last file into the destination dir or the restdir
 #
 	    $logger->debug("keepFile = $keepFile"); 
+
 	    copy( $keepFile, $destdir );
-	    if( $destdir !~ /$dname$/ )
-	    {
-		copy( $keepFile, $restdir )
-	    }
 
 	    foreach my $file (@files) {
 		if( $file ne $keepFile && -f $file ) {
@@ -511,17 +507,35 @@ sub moveFiles
 		move( $file, $destdir );
 	    }
 	}
+    }
 #
 # splice the filename out of the runfiles array so it's not revisited
 # should only match on one filename since they must be unique filenames in the rundir
 #
-	foreach my $file (@files) {
-	    if ( -f $file ) {
-		my @index = grep { $runfiles[$_] eq $file } 0..$#runfiles;
-		splice @runfiles, $index[0], 1;
+    foreach my $file (@files) {
+	if ( -f $file ) {
+	    my @index = grep { $runfiles[$_] eq $file } 0..$#runfiles;
+	    splice @runfiles, $index[0], 1;
+	}
+    }
+# 
+# also get the file that matches the dname for this suffix and
+# copy to the restdir for a complete restart set
+#
+    my @restFiles = grep(/${dname}/, @files);
+    if( $#restFiles == 0 ) {
+	my @path = split /\//, $restFiles[$#restFiles]; 
+	if ( $#path >= 0 ) {
+	    $restFile = $path[$#path];
+	    if ( -f $destdir . "/" . $restFile ) {
+		copy( $destdir . "/" . $restFile, $restdir . "/" . $restFile );
 	    }
 	}
     }
+    elsif( $#restFiles > 0 ) {
+	$logger->info("st_archive: multiple restart files found for suffix=$suffix");
+    }
+
 
     return $numfiles, \@runfiles;
 }
@@ -553,7 +567,7 @@ sub archiveProcess
     chdir ($config{'RUNDIR'});
     my @rpointers = <$config{'RUNDIR'}/rpointer.*>;
     foreach my $rpointer (@rpointers) {
-	    copy( $rpointer, $restdir ) or $logger->logdie("st_archive: Error - cannot copy $rpointer file to directory $restdir. Exiting...");
+	copy( $rpointer, $restdir ) or $logger->logdie("st_archive: Error - cannot copy $rpointer file to directory $restdir. Exiting...");
     }
 #
 # main loop through the comp_archive_spec XML elements handling the associated files accordingly
@@ -575,7 +589,7 @@ sub archiveProcess
 	my @infiles = ($xmlcomp->findnodes('./files/file_extension'));
 	foreach my $infile (@infiles) 
 	{
-	    my $suffix = $infile->getAttribute('suffix');
+	    my $suffix = $infile->getAttribute('regex_suffix');
 	    my $subdir = $infile->findvalue('./subdir');
 	    my $keep_last_in_rundir = $infile->findvalue('./keep_last_in_rundir');
 #
@@ -594,7 +608,7 @@ sub archiveProcess
 		    $ninst_suffix = qq(_$ninst_suffix);
 		}
 #
-# build up the new suffix based on whether the XML suffix starts with a "."
+# build up the new suffix based on whether the XML regex_suffix starts with a "."
 #
 		my $newSuffix = qq($suffix);
 		if( substr($suffix, 0, 1) eq '.' ) {

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -877,9 +877,9 @@ sub _create_caseroot_tools
 	"$cimeroot/scripts/Tools/archive_metadata.sh", 
 	"$cimeroot/scripts/Tools/check_case", 
 	"$cimeroot/scripts/Tools/create_production_test", 
+	"$cimeroot/scripts/Tools/st_archive", 
 	"$cimeroot/scripts/Tools/xmlchange",
 	"$cimeroot/scripts/Tools/xmlquery",
-	"$cimeroot/scripts/Tools/st_archive", 
 	"$cimeroot/scripts/Tools/README.post_process", 
 	); 
     foreach my $file (@files) {
@@ -902,7 +902,6 @@ sub _create_caseroot_tools
     # Copy relevant files into $caseroot/Tools/
     @files = ("$cimeroot/scripts/Tools/check_lockedfiles", 
 	      "$cimeroot/scripts/Tools/lt_archive.sh", 
-	      "$cimeroot/scripts/Tools/st_archive", 
 	      "$cimeroot/scripts/Tools/getTiming", 
 	      "$cimeroot/scripts/Tools/compare_namelists.pl",
 	      "$machines_dir/taskmaker.pl", 


### PR DESCRIPTION
update st_archive to remove the following options, by popular demand:
- DOUT_S_SAVE_DATES_RESTART_FILE_SET
- DOUT_S_CREATE_LINKEDARCHIVE

Other changes include:
- st_archive determines last file for restarts based on matching coupler date in the filename
  rather than sorting on time the file was modified on disk.
- changed attribute suffix to regex_suffix in the archive.xml
- create_newcase now only copies the st_archive script to the caseroot and not the caseroot/Tools
- minor modification to the cimeteststatus.xsd schema so it validates xml output for reporting to the testdb

Test suite: ERR_N3.f19_g16.B1850R.yellowstone_intel.allactive-defaultio
Test baseline: N/A
Test namelist changes: N/A
Test status: N/A

Fixes: user requested changes not listed as CIME issues

Code review:
