### PR TITLE
Remove no-longer-needed CISM_GNU CMake option

### DIFF
--- a/cime_config/cesm/machines/config_compilers.xml
+++ b/cime_config/cesm/machines/config_compilers.xml
@@ -340,7 +340,6 @@ for mct, etc.
   <ADD_CFLAGS compile_threaded="true"> -fopenmp </ADD_CFLAGS>
   <ADD_FFLAGS compile_threaded="true"> -fopenmp </ADD_FFLAGS>
   <ADD_LDFLAGS compile_threaded="true"> -fopenmp </ADD_LDFLAGS>
-  <ADD_CMAKE_OPTS MODEL="cism"> -D CISM_GNU=ON </ADD_CMAKE_OPTS>
   <FIXEDFLAGS>  -ffixed-form </FIXEDFLAGS>
   <FREEFLAGS> -ffree-form </FREEFLAGS>
   <ADD_FFLAGS DEBUG="TRUE"> -g -Wall </ADD_FFLAGS>

--- a/cime_config/cesm/machines/userdefined_laptop_template/config_compilers.xml
+++ b/cime_config/cesm/machines/userdefined_laptop_template/config_compilers.xml
@@ -9,7 +9,6 @@
       <ADD_CFLAGS compile_threaded="true"> -fopenmp </ADD_CFLAGS>
       <ADD_FFLAGS compile_threaded="true"> -fopenmp </ADD_FFLAGS>
       <ADD_LDFLAGS compile_threaded="true"> -L /usr/local/Cellar/gcc/4.9.2/lib/gcc/x86_64-apple-darwin14.0.0/4.9.2 -fopenmp </ADD_LDFLAGS>
-      <ADD_CMAKE_OPTS MODEL="cism"> -D CISM_GNU=ON </ADD_CMAKE_OPTS>
       <FIXEDFLAGS>  -ffixed-form </FIXEDFLAGS>
       <FREEFLAGS> -ffree-form </FREEFLAGS>
       <ADD_FFLAGS DEBUG="TRUE"> -g -Wall </ADD_FFLAGS>
@@ -38,7 +37,6 @@
       <ADD_CFLAGS compile_threaded="true"> -fopenmp </ADD_CFLAGS>
       <ADD_FFLAGS compile_threaded="true"> -fopenmp </ADD_FFLAGS>
       <ADD_LDFLAGS compile_threaded="true"> -fopenmp </ADD_LDFLAGS>
-      <ADD_CMAKE_OPTS MODEL="cism"> -D CISM_GNU=ON </ADD_CMAKE_OPTS>
       <FIXEDFLAGS>  -ffixed-form </FIXEDFLAGS>
       <FREEFLAGS> -ffree-form </FREEFLAGS>
       <ADD_FFLAGS DEBUG="TRUE"> -g -Wall </ADD_FFLAGS>


### PR DESCRIPTION
This introduces a dependency on cism2_1_12: With earlier versions of CISM,
gnu tests will fail to build.

Test suite: yellowstone drv prealpha
Test baseline: cesm1_5_alpha04e
Test namelist changes: none
Test status: bit for bit

Also ran aux_glc test suite

Note: testing was done on 3de3528327f63efa08d14f67ddd005d6f5ff302e
(from branch cism_nag_port - this also included the changes in PR #357 )

Fixes: None

User interface changes?: No

Code review: None
