### PR TITLE
update to config_machines.xml for bluewaters upgrade; update testlist…

### DIFF
--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -259,8 +259,8 @@
   </compset>
 
   <compset>
-    <alias>E1850C5L40CNRTEST</alias>
-    <lname>1850_CAM5_CLM40%SP_CICE_DOCN%SOM_RTM_SGLC_SWAV_TEST</lname>
+    <alias>E1850C5L45TEST</alias>
+    <lname>1850_CAM5_CLM45%SP_CICE_DOCN%SOM_RTM_SGLC_SWAV_TEST</lname>
   </compset>
 
   <compset>

--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -15,22 +15,15 @@
   </compset>
   <compset name="B1850R">
     <grid name="f19_g16">
-      <test name="ERR_N2">
+      <test name="ERR_N3">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">eos</machine>
+        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
       </test>
     </grid>
     <grid name="f45_g37">
       <test name="PEA_P1">
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">hobart</machine>
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">hobart</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850C4L40CNRBDRD">
-    <grid name="f09_g16">
-      <test name="ERS_Ld11">
-        <machine compiler="ibm" testtype="prebeta" testmods="allactive/defaultio">mira</machine>
       </test>
     </grid>
   </compset>
@@ -59,18 +52,15 @@
     <grid name="f09_g16">
       <test name="ERS">
         <machine compiler="pgi" testtype="prealpha" testmods="allactive/defaultio">bluewaters</machine>
-        <machine compiler="ibm" testtype="prealpha" testmods="allactive/defaultio">mira</machine>
+        <machine compiler="cray" testtype="prealpha" testmods="allactive/defaultio">edison</machine>
         <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
       </test>
     </grid>
   </compset>
   <compset name="B1850">
     <grid name="f19_g16">
-      <test name="CME_D_Ld5">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
       <test name="CME_Ld5">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
+        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
       </test>
       <test name="ERS_E_Ld7">
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
@@ -83,7 +73,6 @@
       <test name="ERI">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">eos</machine>
       </test>
       <test name="PFS">
         <machine compiler="pgi " testtype="prebeta" testmods="allactive/default">bluewaters</machine>
@@ -92,43 +81,34 @@
       </test>
     </grid>
     <grid name="f19_g16">
-      <test name="ERS_D_Ld7">
+      <test name="ERS_Ld7">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
         <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
       </test>
       <test name="PET_PT">
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">titan</machine>
         <machine compiler="gnu" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
       </test>
     </grid>
     <grid name="ne120_g16">
       <test name="ERS_Ld9">
-        <machine compiler="ibm" testtype="prebeta" testmods="allactive/defaultio">mira</machine>
+        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
       </test>
     </grid>
     <grid name="ne30_g16">
       <test name="ERI">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
       </test>
-      <test name="ERS_D_Ld7">
-        <machine compiler="ibm" testtype="prebeta" testmods="allactive/defaultio">mira</machine>
-      </test>
       <test name="ERS_IOP_Ld7">
-        <machine compiler="ibm" testtype="prebeta" testmods="allactive/defaultio">mira</machine>
         <machine compiler="gnu" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
       </test>
       <test name="ERS_Ld7">
         <machine compiler="gnu" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
         <machine compiler="gnu" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
       </test>
-      <test name="ERS_Ld9">
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">titan</machine>
-      </test>
       <test name="PET_PT">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">eos</machine>
+        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
       </test>
       <test name="PFS">
-        <machine compiler="ibm " testtype="prebeta" testmods="allactive/default">mira</machine>
         <machine compiler="intel " testtype="prealpha" testmods="allactive/default">yellowstone</machine>
         <machine compiler="intel " testtype="prebeta" testmods="allactive/default">yellowstone</machine>
       </test>
@@ -143,11 +123,6 @@
     </grid>
   </compset>
   <compset name="B1850C4RCO2L40CNR">
-    <grid name="f09_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="ibm" testtype="prebeta" testmods="allactive/defaultio">mira</machine>
-      </test>
-    </grid>
     <grid name="f19_g16">
       <test name="ERS_Ld7">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
@@ -157,8 +132,6 @@
   <compset name="B1850C5WCCML45CNR">
     <grid name="f19_g16">
       <test name="ERS_Ld7">
-        <machine compiler="ibm" testtype="prebeta" testmods="allactive/defaultio">mira</machine>
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
       </test>
     </grid>
@@ -166,32 +139,13 @@
   <compset name="BC4FCHML40CNR">
     <grid name="f19_g16">
       <test name="ERS_Ld7">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC4WCBCL40CNR">
-    <grid name="f19_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">janus</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC5L40SPR">
-    <grid name="ne16_g37">
-      <test name="ERS_Ld7">
-        <machine compiler="intel15" testtype="prebeta" testmods="allactive/defaultio">babbageKnc</machine>
-      </test>
-      <test name="SMS_Ld7">
-        <machine compiler="intel15" testtype="prebeta" testmods="allactive/defaultio">babbageKnc</machine>
       </test>
     </grid>
   </compset>
   <compset name="BC5L45BGCR">
     <grid name="f19_g16">
       <test name="NCK_Ld5">
-        <machine compiler="gnu" testtype="prealpha" testmods="allactive/cism/test_coupling">yellowstone</machine>
         <machine compiler="gnu" testtype="prebeta" testmods="allactive/cism/test_coupling">yellowstone</machine>
       </test>
     </grid>
@@ -205,7 +159,7 @@
   </compset>
   <compset name="B1850C5L45BGCRG2">
     <grid name="T31_g37_gl20">
-      <test name="SMS_D_Ld5">
+      <test name="SMS_Ld5">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/cism/test_coupling">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/cism/test_coupling">yellowstone</machine>
       </test>
@@ -213,7 +167,7 @@
   </compset>
   <compset name="BC5L45BGCRG">
     <grid name="T31_g37_gl20">
-      <test name="SMS_D_Ld5">
+      <test name="SMS_Ld5">
         <machine compiler="nag" testtype="prebeta" testmods="allactive/cism/test_coupling">hobart</machine>
       </test>
     </grid>
@@ -223,13 +177,6 @@
       <test name="NCK_Ld5">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/cism/test_coupling">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/cism/test_coupling">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BHISTC4L40CNRBDRD">
-    <grid name="f09_g16">
-      <test name="ERS_Ld11">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">eos</machine>
       </test>
     </grid>
   </compset>
@@ -246,13 +193,6 @@
     <grid name="ne120_g16">
       <test name="ERS_Ld9">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BHISTC4FCHML40CNR">
-    <grid name="f09_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">eos</machine>
       </test>
     </grid>
   </compset>
@@ -292,7 +232,6 @@
   <compset name="BRCP45C4L40CNRBDRD">
     <grid name="f09_g16">
       <test name="ERS_Ld11">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
       </test>
     </grid>
@@ -307,7 +246,7 @@
   <compset name="BRCP85C5L45BGCR">
     <grid name="f09_g16">
       <test name="ERS">
-        <machine compiler="ibm" testtype="prebeta" testmods="allactive/defaultio">mira</machine>
+        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
       </test>
       <test name="ERS_PT_Ld7">
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
@@ -317,31 +256,14 @@
   <compset name="BC4SSOAL40SPR">
     <grid name="f19_g16">
       <test name="ERS_Ld7">
-        <machine compiler="pgi" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
       </test>
     </grid>
   </compset>
-  <compset name="BC4SSOAL40SPR">
-    <grid name="f19_g16">
-      <test name="ERS_D_Ld7">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
   <compset name="BC4WCMAL40SPR">
     <grid name="f19_g16">
       <test name="ERS_Ld7">
-        <machine compiler="gnu" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
         <machine compiler="gnu" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC4WCMAL40SPR">
-    <grid name="f19_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
       </test>
     </grid>
@@ -354,10 +276,10 @@
       </test>
     </grid>
   </compset>
-  <compset name="E1850C5L40CNRTEST">
+  <compset name="E1850C5L45TEST">
     <grid name="f19_g16">
       <test name="ERS_Ld5">
-	<machine compiler="pgi" testtype="prebeta" testmods="cice/default">yellowstone</machine>
+	<machine compiler="intel" testtype="prebeta" testmods="cice/default">yellowstone</machine>
 	</test>
     </grid>
   </compset>

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -308,7 +308,7 @@
       </modules>
       <modules compiler="pgi">
 	<command name="load">PrgEnv-pgi</command>
-	<command name="switch">pgi pgi/15.7.0</command>
+	<command name="switch">pgi pgi/15.10.0</command>
       </modules>
       <modules compiler="gnu">
 	<command name="load">PrgEnv-gnu/4.2.84</command>
@@ -320,16 +320,16 @@
       </modules>
       <modules>
 	<command name="load">papi/5.3.2</command>
-	<command name="switch">cray-mpich cray-mpich/7.0.3</command>
-	<command name="switch">cray-libsci cray-libsci/12.2.0</command>
+	<command name="switch">cray-mpich cray-mpich/7.3.0</command>
+	<command name="switch">cray-libsci cray-libsci/13.3.0</command>
 	<command name="load">torque/5.0.1</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.3.2</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.3.3.1</command>
 	<command name="load">cray-parallel-netcdf/1.6.1</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-netcdf/4.3.2</command>
+	<command name="load">cray-netcdf/4.3.3.1</command>
       </modules>
       <modules>
 	<command name="load">cmake/3.1.3</command>


### PR DESCRIPTION
…_allactive.xml
- Changes to the bluewaters default modules in config_machines.xml.
- Remove debug option (_D) from the coupled tests to save time.
- Remove titan, eos and mira from testlist_allactive.xml.
- Change test E1850C5L40CNRTEST to E1850C5L45TEST in testlist_allactive.xml
  and config_compsets.xml.

Test suite: prealpha on bluewaters for config_machines.xml
Test baseline: cesm1_5_alpha05a
Test namelist changes:
Test status: bit for bit

Fixes: none

Code review: 
