### PR TITLE
add T85_T85 to config_grids.xml

### DIFF
--- a/cime_config/cesm/config_grids.xml
+++ b/cime_config/cesm/config_grids.xml
@@ -121,6 +121,12 @@
       <lname>a%T42_l%T42_oi%T42_r%r05_m%usgs_g%null_w%null</lname>
     </grid>
 
+    <grid compset="(DOCN|XOCN|SOCN)">
+      <sname>T85_T85</sname>
+      <alias>T85_T85</alias>
+      <lname>a%T85_l%T85_oi%T85_r%r05_m%usgs_g%null_w%null</lname>
+    </grid>
+
     <grid compset="(DATM|XATM|SATM)">
       <sname>T62_gx3v7</sname>
       <alias>T62_g37</alias>

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -2881,6 +2881,7 @@
       <value compset=".+" grid="a%ne60np4"  >96</value>
       <value compset=".+" grid="a%ne120np4" >96</value>
       <value compset=".+" grid="a%ne240np4" >96</value>
+      <value compset=".+" grid="a%T42"      >72</value>
       <value compset=".+" grid="a%T85"      >144</value>
       <value compset=".+" grid="a%T341"     >288</value>
       <value compset=".+" grid="1x1"        >48</value>


### PR DESCRIPTION
Specifying the T85_T85 grid gave the following output:
ERROR: no supported grid match for target grid T85_T85
I added a T85_T85 entry to config_grids.xml analogous to
the existing T42_T42 entry.  This fixed the problem.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes: [CIME Github issue #]

User interface changes?: [Yes (describe what changes), No]

Code review:
