### PR TITLE
update config_batch.xml to remove pbs directives

### DIFF
--- a/cime_config/cesm/machines/config_batch.xml
+++ b/cime_config/cesm/machines/config_batch.xml
@@ -77,8 +77,6 @@
     </submit_args>
     <directives>
       <directive> -N {{ job_id }}</directive>
-      <directive> -q {{ queue }}</directive>
-      <directive> -l walltime={{ wall_time }}</directive>
       <directive default="n"> -r {{ rerunnable }} </directive>
       <!-- <directive> -j oe {{ output_error_path }} </directive> -->
       <directive> -j oe </directive>


### PR DESCRIPTION
The queue and wallclock time were being set in 2 places for the PBS batch system.
The case dir env_batch.xml controls the arguments to the qsub command and
the config_batch.xml directive element entries are ignored in favor of the
qsub command line args. Remove the redundant directive elements from
the config_batch.xml file.

Test suite: SMS_D_ld3.f45_g37_rc1.A.hobart_nag
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes: related to CIME issue #49

Code review:
