### PR TITLE
minor update for testing

### DIFF
--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -23,6 +23,9 @@
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
         <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
       </test>
+      <test name="ERR">
+        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">edison</machine>
+      </test>
       <test name="NCR">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
       </test>

--- a/scripts/Testing/testreporter.pl
+++ b/scripts/Testing/testreporter.pl
@@ -309,7 +309,7 @@ sub getTestStatus
 	# test functionality summary as the teststatus field.
 	my @testsummarylines = grep { /test functionality summary/ } @statuslines;
 	my $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
-	if(defined $testsummary && $testsummary !~ /PASS/)
+	if((defined $testsummary && $testsummary !~ /PASS/) && ($teststatus !~ /DONE/))
 	{
 	    $teststatus = $testsummary;
 	    $teststatushash{$testcase}{'comment'} = "Overall Test status failed! Check the history files!!";


### PR DESCRIPTION
Update testreporter.pl to report teststatus as overall runtime status when
it is DONE even if test functionality reports FAIL due to namelist comparison.
Add ERR.f19_g16.B1850 to edison prealpha testlist.

Test suite: N/A
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes: N/A

Code review:
