### PR TITLE
fix testreporter.pl, SMS and PFS test output, cori queue settings

### DIFF
--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -26,9 +26,6 @@
       <test name="ERR">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">edison</machine>
       </test>
-      <test name="NCR">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
       <test name="PET_PT">
         <machine compiler="gnu" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
       </test>
@@ -60,7 +57,7 @@
   </compset>
   <compset name="B1850C4L45BGCRBPRP">
     <grid name="f19_g16">
-      <test name="ERS_Ld11">
+      <test name="ERS">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
       </test>
     </grid>
@@ -128,7 +125,7 @@
   </compset>
   <compset name="B1850RG">
     <grid name="f09_g16">
-      <test name="ERS_Ld11">
+      <test name="ERS">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01io">yellowstone</machine>
       </test>
       <test name="PFS">
@@ -141,7 +138,7 @@
   </compset>
   <compset name="B1850RW">
     <grid name="f19_g16">
-      <test name="ERS_Ld11">
+      <test name="ERS">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
       </test>
     </grid>
@@ -249,7 +246,7 @@
   </compset>
   <compset name="BRCP45C4L40CNRBDRD">
     <grid name="f09_g16">
-      <test name="ERS_Ld11">
+      <test name="ERS">
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
       </test>
     </grid>

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -556,19 +556,11 @@
     <PES_PER_NODE>32</PES_PER_NODE>
     <batch_system type="slurm" version="x.y">
       <queues>
-        <queue walltimemax="06:00:00" jobmin="1" jobmax="16384" default="true">regular</queue>
-		<!--
-        <queue walltimemax="04:00:00" jobmin="16385" jobmax="32768" >regular</queue>
-        <queue walltimemax="02:00:00" jobmin="32769" jobmax="52096" >regular</queue>
-	    <queue walltimemax="00:30:00" jobmin="1" jobmax="4096" default="true">debug</queue>
-        -->
+        <queue walltimemax="06:00:00" jobmin="1" jobmax="45440">regular</queue>
+	<queue walltimemax="00:30:00" jobmin="1" jobmax="3072" default="true">debug</queue>
       </queues>
       <walltimes>
-	<walltime default="true">04:00:00</walltime>
-    <!--
-	<walltime ccsm_estcost="1">01:50:00</walltime>
-	<walltime ccsm_estcost="3">05:00:00</walltime>
-    -->
+	<walltime default="true">00:30:00</walltime>
       </walltimes>
     </batch_system>
     <mpirun mpilib="default">

--- a/cime_config/xml_schemas/testlist.xsd
+++ b/cime_config/xml_schemas/testlist.xsd
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!-- definition of attributes -->
+  <xs:attribute name="name" type="xs:string"/>
+  <xs:attribute name="compiler" type="xs:string"/>
+  <xs:attribute name="testtype" type="xs:string"/>
+  <xs:attribute name="testmods" type="xs:string"/>
+
+  <!-- definition of complex elements -->
+  <xs:element name="machine">
+    <xs:complexType>
+      <xs:simpleContent>
+	<xs:extension base="xs:string">
+	  <xs:attribute ref="compiler" use="required"/>
+	  <xs:attribute ref="testtype" use="required"/>
+	  <xs:attribute ref="testmods" use="required"/>
+	</xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="test">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element ref="machine" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute ref="name" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="grid">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element ref="test" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute ref="name" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="compset">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element ref="grid" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute ref="name" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="testlist">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element ref="compset" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/scripts/Testing/Testcases/PFS_script
+++ b/scripts/Testing/Testcases/PFS_script
@@ -45,10 +45,12 @@ endif
 #======================================================================
 
 echo "DONE ${CASEBASEID} : (test finished, successful coupler log) " >>& $TESTSTATUS_LOG
+echo "PASS ${CASEBASEID} : test functionality summary " >>& $TESTSTATUS_LOG
 echo "" >>& $TESTSTATUS_LOG
 
 echo "DONE ${CASEBASEID} : (test finished, successful coupler log) " >&! $TESTSTATUS_OUT
 echo "--- Test Functionality: ---" >>& $TESTSTATUS_OUT
+echo "PASS ${CASEBASEID} : test functionality summary " >>& $TESTSTATUS_OUT
 echo "this test just measures performance - so there are no PASS/FAIL metrics"
 
 

--- a/scripts/Testing/Testcases/SMS_script
+++ b/scripts/Testing/Testcases/SMS_script
@@ -68,6 +68,7 @@ if ! ( $?IOP_ON ) then
 endif
 
 echo "DONE ${CASEBASEID} : ($msg finished, successful coupler log) " >>& $TESTSTATUS_LOG
+echo "PASS ${CASEBASEID} : test functionality summary " >>& $TESTSTATUS_LOG
 echo "" >>& $TESTSTATUS_LOG
 
 if ( $?IOP_ON ) then
@@ -76,6 +77,7 @@ if ( $?IOP_ON ) then
     $SCRIPTSROOT/Tools/component_compare_test.sh -rundir $RUNDIR -testcase $CASE -testcase_base $CASEBASEID -suffix1 base -suffix2 none $add_iop -msg "$msg" >>& $TESTSTATUS_OUT
 else
    echo "PASS ${CASEBASEID} : successful coupler log " >>& $TESTSTATUS_OUT
+   echo "PASS ${CASEBASEID} : test functionality summary " >>& $TESTSTATUS_OUT
 endif
 
 


### PR DESCRIPTION
Modify testreporter.pl to output true test functionality summary and
---- when tests are not run. Update SMS and PFS to ouput test functionality
summary to the caseroot TestStatus file. Update cori queue settings in
config_machines.xml. Remove NCR test because it never worked.
Remove Ld11 from testlist. Add testlist.xsd schema.

Test suite: reran testreporter for cesm1_5_alpha06b YS/intel results
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes: partial fix to #257, fixes #385

Code review: Chris Fischer
