### PR TITLE
Bring cime4.4.5_cntlexp changes to master and change B1850 PE layout

### DIFF
--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -71,7 +71,7 @@
 
   <compset>
     <alias>B1850</alias>
-    <lname>1850_CAM55_CLM50%BGC-CROP_CICE_POP2_MOSART_SGLC_SWAV</lname>
+    <lname>1850_CAM55_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD</lname>
   </compset>
 
   <compset>

--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -275,6 +275,22 @@
   </compset>
 
   <entries>
+
+ <entry id="RUN_TYPE">
+      <values>
+	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"	compset="1850_CAM55_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD"	   >hybrid</value>
+      </values>
+    </entry>
+    <entry id="RUN_REFCASE">
+      <values>
+	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"   compset="1850_CAM55_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD">b.e15.B1850G.f09_g16.pi_control.25</value>
+      </values>
+    </entry>
+    <entry id="RUN_REFDATE">
+      <values>
+	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"		compset="1850_CAM55_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD"			   >0041-01-01</value>
+      </values>
+    </entry>
 <!-- Reference cases from older cesm versions are no longer valid
     <entry id="RUN_TYPE">
       <values>

--- a/cime_config/cesm/allactive/config_pes.xml
+++ b/cime_config/cesm/allactive/config_pes.xml
@@ -1372,13 +1372,13 @@
     <mach name="yellowstone">
       <pes pesize="X" compset="CAM5.+CLM.+CICE.+POP.+">
 	<PES_PER_NODE>16</PES_PER_NODE>
-	<MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
+	<MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
 	<comment>none</comment>
 	<ntasks>
 	  <ntasks_atm>-108</ntasks_atm>
-	  <ntasks_lnd>-92</ntasks_lnd>
-	  <ntasks_rof>-92</ntasks_rof>
-	  <ntasks_ice>-16</ntasks_ice>
+	  <ntasks_lnd>-68</ntasks_lnd>
+	  <ntasks_rof>-68</ntasks_rof>
+	  <ntasks_ice>-40</ntasks_ice>
 	  <ntasks_ocn>-10</ntasks_ocn>
 	  <ntasks_glc>1</ntasks_glc>
 	  <ntasks_wav>1</ntasks_wav>
@@ -1398,7 +1398,7 @@
 	  <rootpe_atm>0</rootpe_atm>
 	  <rootpe_lnd>0</rootpe_lnd>
 	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>-92</rootpe_ice>
+	  <rootpe_ice>-68</rootpe_ice>
 	  <rootpe_ocn>-108</rootpe_ocn>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>0</rootpe_wav>

--- a/cime_config/cesm/allactive/config_pes.xml
+++ b/cime_config/cesm/allactive/config_pes.xml
@@ -7,34 +7,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-3</ntasks_atm> 
-	  <ntasks_lnd>-1</ntasks_lnd>           
-	  <ntasks_rof>-1</ntasks_rof> 
-	  <ntasks_ice>-2</ntasks_ice> 
-	  <ntasks_ocn>-1</ntasks_ocn> 
-	  <ntasks_glc>-1</ntasks_glc> 
-	  <ntasks_wav>-1</ntasks_wav> 
-	  <ntasks_cpl>-3</ntasks_cpl> 
+	  <ntasks_atm>-3</ntasks_atm>
+	  <ntasks_lnd>-1</ntasks_lnd>
+	  <ntasks_rof>-1</ntasks_rof>
+	  <ntasks_ice>-2</ntasks_ice>
+	  <ntasks_ocn>-1</ntasks_ocn>
+	  <ntasks_glc>-1</ntasks_glc>
+	  <ntasks_wav>-1</ntasks_wav>
+	  <ntasks_cpl>-3</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>-1</rootpe_ice>    
-	  <rootpe_ocn>-3</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>-1</rootpe_ice>
+	  <rootpe_ocn>-3</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -44,34 +44,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-4</ntasks_atm> 
-	  <ntasks_lnd>-2</ntasks_lnd>           
-	  <ntasks_rof>-2</ntasks_rof> 
-	  <ntasks_ice>-2</ntasks_ice> 
-	  <ntasks_ocn>-2</ntasks_ocn> 
-	  <ntasks_glc>-1</ntasks_glc> 
-	  <ntasks_wav>-1</ntasks_wav> 
-	  <ntasks_cpl>-4</ntasks_cpl> 
+	  <ntasks_atm>-4</ntasks_atm>
+	  <ntasks_lnd>-2</ntasks_lnd>
+	  <ntasks_rof>-2</ntasks_rof>
+	  <ntasks_ice>-2</ntasks_ice>
+	  <ntasks_ocn>-2</ntasks_ocn>
+	  <ntasks_glc>-1</ntasks_glc>
+	  <ntasks_wav>-1</ntasks_wav>
+	  <ntasks_cpl>-4</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>-2</rootpe_ice>    
-	  <rootpe_ocn>-4</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>-2</rootpe_ice>
+	  <rootpe_ocn>-4</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -81,34 +81,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-16</ntasks_atm> 
-	  <ntasks_lnd>-9</ntasks_lnd>           
-	  <ntasks_rof>-9</ntasks_rof> 
-	  <ntasks_ice>-7</ntasks_ice> 
-	  <ntasks_ocn>-1</ntasks_ocn> 
-	  <ntasks_glc>-1</ntasks_glc> 
-	  <ntasks_wav>-1</ntasks_wav> 
-	  <ntasks_cpl>-16</ntasks_cpl> 
+	  <ntasks_atm>-16</ntasks_atm>
+	  <ntasks_lnd>-9</ntasks_lnd>
+	  <ntasks_rof>-9</ntasks_rof>
+	  <ntasks_ice>-7</ntasks_ice>
+	  <ntasks_ocn>-1</ntasks_ocn>
+	  <ntasks_glc>-1</ntasks_glc>
+	  <ntasks_wav>-1</ntasks_wav>
+	  <ntasks_cpl>-16</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>                   
-	  <nthrds_lnd>8</nthrds_lnd> 
-	  <nthrds_rof>8</nthrds_rof> 
-	  <nthrds_ice>8</nthrds_ice> 
-	  <nthrds_ocn>8</nthrds_ocn> 
-	  <nthrds_glc>8</nthrds_glc> 
-	  <nthrds_wav>8</nthrds_wav> 
-	  <nthrds_cpl>8</nthrds_cpl> 
+	  <nthrds_atm>8</nthrds_atm>
+	  <nthrds_lnd>8</nthrds_lnd>
+	  <nthrds_rof>8</nthrds_rof>
+	  <nthrds_ice>8</nthrds_ice>
+	  <nthrds_ocn>8</nthrds_ocn>
+	  <nthrds_glc>8</nthrds_glc>
+	  <nthrds_wav>8</nthrds_wav>
+	  <nthrds_cpl>8</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>-9</rootpe_ice>    
-	  <rootpe_ocn>-16</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>-9</rootpe_ice>
+	  <rootpe_ocn>-16</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -118,24 +118,24 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>60</ntasks_atm> 
-	  <ntasks_lnd>15</ntasks_lnd> 
-	  <ntasks_rof>15</ntasks_rof> 
-	  <ntasks_ice>45</ntasks_ice> 
-	  <ntasks_ocn>15</ntasks_ocn> 
-	  <ntasks_glc>60</ntasks_glc> 
-	  <ntasks_wav>60</ntasks_wav> 
-	  <ntasks_cpl>60</ntasks_cpl> 
+	  <ntasks_atm>60</ntasks_atm>
+	  <ntasks_lnd>15</ntasks_lnd>
+	  <ntasks_rof>15</ntasks_rof>
+	  <ntasks_ice>45</ntasks_ice>
+	  <ntasks_ocn>15</ntasks_ocn>
+	  <ntasks_glc>60</ntasks_glc>
+	  <ntasks_wav>60</ntasks_wav>
+	  <ntasks_cpl>60</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -152,27 +152,27 @@
   </grid>
   <grid name="a%ne16.+l%ne16.+oi%gx3.+r%r05.+g%null_w%null" >
     <mach name="yellowstone">
-      <pes pesize="any" compset="2000_CAM5_CLM40%SP_CICE_POP2_RTM_SGLC_SWAV"> 
+      <pes pesize="any" compset="2000_CAM5_CLM40%SP_CICE_POP2_RTM_SGLC_SWAV">
 	<comment>js 16 sep 2014 ne16_g37 bc5 yellowstone-specific pe layout used for low res ensemble</comment>
 	<ntasks>
-	  <ntasks_atm>96</ntasks_atm> 
-	  <ntasks_lnd>80</ntasks_lnd> 
-	  <ntasks_rof>80</ntasks_rof> 
-	  <ntasks_ice>80</ntasks_ice> 
-	  <ntasks_ocn>16</ntasks_ocn> 
-	  <ntasks_glc>96</ntasks_glc> 
-	  <ntasks_wav>96</ntasks_wav> 
-	  <ntasks_cpl>96</ntasks_cpl> 
+	  <ntasks_atm>96</ntasks_atm>
+	  <ntasks_lnd>80</ntasks_lnd>
+	  <ntasks_rof>80</ntasks_rof>
+	  <ntasks_ice>80</ntasks_ice>
+	  <ntasks_ocn>16</ntasks_ocn>
+	  <ntasks_glc>96</ntasks_glc>
+	  <ntasks_wav>96</ntasks_wav>
+	  <ntasks_cpl>96</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -187,39 +187,39 @@
       </pes>
     </mach>
   </grid>
-  <grid name="a%ne30np4.+l%ne30np4.+oi%gx1" > 
+  <grid name="a%ne30np4.+l%ne30np4.+oi%gx1" >
     <mach name="any">
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-8</ntasks_atm> 
-	  <ntasks_lnd>-8</ntasks_lnd>           
-	  <ntasks_rof>-8</ntasks_rof> 
-	  <ntasks_ice>-8</ntasks_ice> 
-	  <ntasks_ocn>-8</ntasks_ocn> 
-	  <ntasks_glc>-8</ntasks_glc> 
-	  <ntasks_wav>-8</ntasks_wav> 
-	  <ntasks_cpl>-8</ntasks_cpl> 
+	  <ntasks_atm>-8</ntasks_atm>
+	  <ntasks_lnd>-8</ntasks_lnd>
+	  <ntasks_rof>-8</ntasks_rof>
+	  <ntasks_ice>-8</ntasks_ice>
+	  <ntasks_ocn>-8</ntasks_ocn>
+	  <ntasks_glc>-8</ntasks_glc>
+	  <ntasks_wav>-8</ntasks_wav>
+	  <ntasks_cpl>-8</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -229,34 +229,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-16</ntasks_atm> 
-	  <ntasks_lnd>-16</ntasks_lnd>           
-	  <ntasks_rof>-16</ntasks_rof> 
-	  <ntasks_ice>-16</ntasks_ice> 
-	  <ntasks_ocn>-16</ntasks_ocn> 
-	  <ntasks_glc>-16</ntasks_glc> 
-	  <ntasks_wav>-16</ntasks_wav> 
-	  <ntasks_cpl>-16</ntasks_cpl> 
+	  <ntasks_atm>-16</ntasks_atm>
+	  <ntasks_lnd>-16</ntasks_lnd>
+	  <ntasks_rof>-16</ntasks_rof>
+	  <ntasks_ice>-16</ntasks_ice>
+	  <ntasks_ocn>-16</ntasks_ocn>
+	  <ntasks_glc>-16</ntasks_glc>
+	  <ntasks_wav>-16</ntasks_wav>
+	  <ntasks_cpl>-16</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -266,33 +266,33 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>2600</ntasks_atm>		
-	  <ntasks_lnd>144</ntasks_lnd>		
-	  <ntasks_rof>144</ntasks_rof>  
-	  <ntasks_ice>2456</ntasks_ice>		
-	  <ntasks_ocn>192</ntasks_ocn>		
-	  <ntasks_glc>1</ntasks_glc>		
+	  <ntasks_atm>2600</ntasks_atm>
+	  <ntasks_lnd>144</ntasks_lnd>
+	  <ntasks_rof>144</ntasks_rof>
+	  <ntasks_ice>2456</ntasks_ice>
+	  <ntasks_ocn>192</ntasks_ocn>
+	  <ntasks_glc>1</ntasks_glc>
 	  <ntasks_wav>192</ntasks_wav>
-	  <ntasks_cpl>2600</ntasks_cpl>	
+	  <ntasks_cpl>2600</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>		
-	  <nthrds_lnd>8</nthrds_lnd>	
-	  <nthrds_ice>8</nthrds_ice>	
-	  <nthrds_rof>8</nthrds_rof>	
-	  <nthrds_ocn>8</nthrds_ocn>	
-	  <nthrds_glc>8</nthrds_glc>	
+	  <nthrds_atm>8</nthrds_atm>
+	  <nthrds_lnd>8</nthrds_lnd>
+	  <nthrds_ice>8</nthrds_ice>
+	  <nthrds_rof>8</nthrds_rof>
+	  <nthrds_ocn>8</nthrds_ocn>
+	  <nthrds_glc>8</nthrds_glc>
 	  <nthrds_wav>8</nthrds_wav>
 	  <nthrds_cpl>8</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>				     
-	  <rootpe_lnd>0</rootpe_lnd>			     
-	  <rootpe_ice>144</rootpe_ice>			     
-	  <rootpe_rof>0</rootpe_rof>			     
-	  <rootpe_ocn>2600</rootpe_ocn>			     
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>2600</rootpe_wav> 
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_ice>144</rootpe_ice>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ocn>2600</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>2600</rootpe_wav>
 	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
@@ -303,30 +303,30 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>960</ntasks_atm> 
-	  <ntasks_lnd>48</ntasks_lnd>  
-	  <ntasks_rof>48</ntasks_rof>  
-	  <ntasks_ice>912</ntasks_ice> 
-	  <ntasks_ocn>48</ntasks_ocn>  
-	  <ntasks_glc>1</ntasks_glc>   
+	  <ntasks_atm>960</ntasks_atm>
+	  <ntasks_lnd>48</ntasks_lnd>
+	  <ntasks_rof>48</ntasks_rof>
+	  <ntasks_ice>912</ntasks_ice>
+	  <ntasks_ocn>48</ntasks_ocn>
+	  <ntasks_glc>1</ntasks_glc>
 	  <ntasks_wav>960</ntasks_wav>
-	  <ntasks_cpl>960</ntasks_cpl> 
+	  <ntasks_cpl>960</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>4</nthrds_atm> 
-	  <nthrds_lnd>4</nthrds_lnd> 
-	  <nthrds_rof>4</nthrds_rof> 
-	  <nthrds_ice>4</nthrds_ice> 
-	  <nthrds_ocn>4</nthrds_ocn> 
-	  <nthrds_glc>4</nthrds_glc> 
-	  <nthrds_wav>4</nthrds_wav> 
-	  <nthrds_cpl>4</nthrds_cpl> 
+	  <nthrds_atm>4</nthrds_atm>
+	  <nthrds_lnd>4</nthrds_lnd>
+	  <nthrds_rof>4</nthrds_rof>
+	  <nthrds_ice>4</nthrds_ice>
+	  <nthrds_ocn>4</nthrds_ocn>
+	  <nthrds_glc>4</nthrds_glc>
+	  <nthrds_wav>4</nthrds_wav>
+	  <nthrds_cpl>4</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
 	  <rootpe_lnd>0</rootpe_lnd>
 	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>48</rootpe_ice> 
+	  <rootpe_ice>48</rootpe_ice>
 	  <rootpe_ocn>960</rootpe_ocn>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>0</rootpe_wav>
@@ -340,34 +340,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>900</ntasks_atm>		
-	  <ntasks_lnd>300</ntasks_lnd>		
-	  <ntasks_rof>300</ntasks_rof>		
-	  <ntasks_ice>600</ntasks_ice>		
-	  <ntasks_ocn>60</ntasks_ocn>			
-	  <ntasks_glc>900</ntasks_glc>	
-	  <ntasks_wav>900</ntasks_wav>	
-	  <ntasks_cpl>900</ntasks_cpl>	
+	  <ntasks_atm>900</ntasks_atm>
+	  <ntasks_lnd>300</ntasks_lnd>
+	  <ntasks_rof>300</ntasks_rof>
+	  <ntasks_ice>600</ntasks_ice>
+	  <ntasks_ocn>60</ntasks_ocn>
+	  <ntasks_glc>900</ntasks_glc>
+	  <ntasks_wav>900</ntasks_wav>
+	  <ntasks_cpl>900</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>		
-	  <nthrds_lnd>2</nthrds_lnd>	
-	  <nthrds_rof>2</nthrds_rof>	
-	  <nthrds_ice>2</nthrds_ice>	
-	  <nthrds_ocn>2</nthrds_ocn>	
-	  <nthrds_cpl>2</nthrds_cpl>	
-	  <nthrds_wav>2</nthrds_wav>	
-	  <nthrds_glc>2</nthrds_glc>	
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_cpl>2</nthrds_cpl>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_glc>2</nthrds_glc>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>           
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>300</rootpe_ice> 	     
-	  <rootpe_ocn>900</rootpe_ocn> 	     
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl> 
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>300</rootpe_ice>
+	  <rootpe_ocn>900</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -377,34 +377,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>1024</ntasks_atm> 
-	  <ntasks_lnd>1024</ntasks_lnd>           
-	  <ntasks_rof>1024</ntasks_rof> 
-	  <ntasks_ice>1024</ntasks_ice> 
-	  <ntasks_ocn>1024</ntasks_ocn> 
-	  <ntasks_glc>1024</ntasks_glc> 
-	  <ntasks_wav>1024</ntasks_wav> 
-	  <ntasks_cpl>1024</ntasks_cpl> 
+	  <ntasks_atm>1024</ntasks_atm>
+	  <ntasks_lnd>1024</ntasks_lnd>
+	  <ntasks_rof>1024</ntasks_rof>
+	  <ntasks_ice>1024</ntasks_ice>
+	  <ntasks_ocn>1024</ntasks_ocn>
+	  <ntasks_glc>1024</ntasks_glc>
+	  <ntasks_wav>1024</ntasks_wav>
+	  <ntasks_cpl>1024</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -414,30 +414,30 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>12384</ntasks_atm>		
-	  <ntasks_lnd>96</ntasks_lnd>			
-	  <ntasks_rof>96</ntasks_rof>  
-	  <ntasks_ice>12288</ntasks_ice>		
-	  <ntasks_ocn>4000</ntasks_ocn>		
-	  <ntasks_glc>1</ntasks_glc>			
-	  <ntasks_wav>4000</ntasks_wav>	
-	  <ntasks_cpl>12384</ntasks_cpl>	
+	  <ntasks_atm>12384</ntasks_atm>
+	  <ntasks_lnd>96</ntasks_lnd>
+	  <ntasks_rof>96</ntasks_rof>
+	  <ntasks_ice>12288</ntasks_ice>
+	  <ntasks_ocn>4000</ntasks_ocn>
+	  <ntasks_glc>1</ntasks_glc>
+	  <ntasks_wav>4000</ntasks_wav>
+	  <ntasks_cpl>12384</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>		
-	  <nthrds_lnd>8</nthrds_lnd>	
-	  <nthrds_rof>8</nthrds_rof>	
-	  <nthrds_ice>8</nthrds_ice>	
-	  <nthrds_ocn>8</nthrds_ocn>	
-	  <nthrds_wav>8</nthrds_wav>		
-	  <nthrds_cpl>8</nthrds_cpl>	
-	  <nthrds_glc>8</nthrds_glc>	
+	  <nthrds_atm>8</nthrds_atm>
+	  <nthrds_lnd>8</nthrds_lnd>
+	  <nthrds_rof>8</nthrds_rof>
+	  <nthrds_ice>8</nthrds_ice>
+	  <nthrds_ocn>8</nthrds_ocn>
+	  <nthrds_wav>8</nthrds_wav>
+	  <nthrds_cpl>8</nthrds_cpl>
+	  <nthrds_glc>8</nthrds_glc>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>	    
-	  <rootpe_lnd>0</rootpe_lnd>	    
-	  <rootpe_rof>0</rootpe_rof>	    
-	  <rootpe_ice>96</rootpe_ice>	    
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>96</rootpe_ice>
 	  <rootpe_ocn>12384</rootpe_ocn>
 	  <rootpe_wav>0</rootpe_wav>
 	  <rootpe_cpl>0</rootpe_cpl>
@@ -451,34 +451,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>1440</ntasks_atm> 
-	  <ntasks_lnd>1440</ntasks_lnd>  
-	  <ntasks_rof>1440</ntasks_rof>  
-	  <ntasks_ice>512</ntasks_ice>  
-	  <ntasks_ocn>2048</ntasks_ocn> 
-	  <ntasks_glc>1440</ntasks_glc> 
-	  <ntasks_wav>1440</ntasks_wav> 
-	  <ntasks_cpl>1440</ntasks_cpl>  
+	  <ntasks_atm>1440</ntasks_atm>
+	  <ntasks_lnd>1440</ntasks_lnd>
+	  <ntasks_rof>1440</ntasks_rof>
+	  <ntasks_ice>512</ntasks_ice>
+	  <ntasks_ocn>2048</ntasks_ocn>
+	  <ntasks_glc>1440</ntasks_glc>
+	  <ntasks_wav>1440</ntasks_wav>
+	  <ntasks_cpl>1440</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm> 
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>   
-	  <rootpe_lnd>0</rootpe_lnd>   
-	  <rootpe_rof>0</rootpe_rof>   
-	  <rootpe_ice>0</rootpe_ice>   
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
 	  <rootpe_ocn>1440</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>   
+	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>   
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -488,30 +488,30 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>4096</ntasks_atm>				 
-	  <ntasks_lnd>2048</ntasks_lnd>			 
-	  <ntasks_rof>512</ntasks_rof>			 
-	  <ntasks_ice>2048</ntasks_ice>		
-	  <ntasks_ocn>512</ntasks_ocn>		
-	  <ntasks_glc>4096</ntasks_glc>	
-	  <ntasks_wav>4096</ntasks_wav>	
-	  <ntasks_cpl>4096</ntasks_cpl>	
+	  <ntasks_atm>4096</ntasks_atm>
+	  <ntasks_lnd>2048</ntasks_lnd>
+	  <ntasks_rof>512</ntasks_rof>
+	  <ntasks_ice>2048</ntasks_ice>
+	  <ntasks_ocn>512</ntasks_ocn>
+	  <ntasks_glc>4096</ntasks_glc>
+	  <ntasks_wav>4096</ntasks_wav>
+	  <ntasks_cpl>4096</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>		
-	  <nthrds_lnd>2</nthrds_lnd>	
-	  <nthrds_rof>2</nthrds_rof>	
-	  <nthrds_ice>2</nthrds_ice>	
-	  <nthrds_ocn>2</nthrds_ocn>	
-	  <nthrds_glc>2</nthrds_glc>	
-	  <nthrds_wav>2</nthrds_wav>	
-	  <nthrds_cpl>2</nthrds_cpl>	
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>	    
-	  <rootpe_lnd>0</rootpe_lnd>	    
-	  <rootpe_rof>0</rootpe_rof>	    
-	  <rootpe_ice>2048</rootpe_ice>	    
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>2048</rootpe_ice>
 	  <rootpe_ocn>4096</rootpe_ocn>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>0</rootpe_wav>
@@ -525,30 +525,30 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>4096</ntasks_atm>				 
-	  <ntasks_lnd>2048</ntasks_lnd>			 
-	  <ntasks_rof>2048</ntasks_rof>			 
-	  <ntasks_ice>2048</ntasks_ice>		
-	  <ntasks_ocn>512</ntasks_ocn>		
-	  <ntasks_glc>4096</ntasks_glc>	
-	  <ntasks_wav>4096</ntasks_wav>	
-	  <ntasks_cpl>4096</ntasks_cpl>	
+	  <ntasks_atm>4096</ntasks_atm>
+	  <ntasks_lnd>2048</ntasks_lnd>
+	  <ntasks_rof>2048</ntasks_rof>
+	  <ntasks_ice>2048</ntasks_ice>
+	  <ntasks_ocn>512</ntasks_ocn>
+	  <ntasks_glc>4096</ntasks_glc>
+	  <ntasks_wav>4096</ntasks_wav>
+	  <ntasks_cpl>4096</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm>		
-	  <nthrds_lnd>2</nthrds_lnd>	
-	  <nthrds_rof>2</nthrds_rof>	
-	  <nthrds_ice>2</nthrds_ice>	
-	  <nthrds_ocn>2</nthrds_ocn>	
-	  <nthrds_cpl>2</nthrds_cpl>	
-	  <nthrds_glc>2</nthrds_glc>	
-	  <nthrds_wav>2</nthrds_wav>	
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_cpl>2</nthrds_cpl>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>	    
-	  <rootpe_lnd>0</rootpe_lnd>	    
-	  <rootpe_rof>0</rootpe_rof>	    
-	  <rootpe_ice>2048</rootpe_ice>	    
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>2048</rootpe_ice>
 	  <rootpe_ocn>4096</rootpe_ocn>
 	  <rootpe_cpl>0</rootpe_cpl>
 	  <rootpe_glc>0</rootpe_glc>
@@ -562,30 +562,30 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>9600</ntasks_atm> 
-	  <ntasks_lnd>8640</ntasks_lnd> 
-	  <ntasks_rof>600</ntasks_rof>  
-	  <ntasks_ice>960</ntasks_ice> 
-	  <ntasks_ocn>960</ntasks_ocn> 
-	  <ntasks_glc>960</ntasks_glc> 
-	  <ntasks_wav>960</ntasks_wav> 
-	  <ntasks_cpl>960</ntasks_cpl> 
+	  <ntasks_atm>9600</ntasks_atm>
+	  <ntasks_lnd>8640</ntasks_lnd>
+	  <ntasks_rof>600</ntasks_rof>
+	  <ntasks_ice>960</ntasks_ice>
+	  <ntasks_ocn>960</ntasks_ocn>
+	  <ntasks_glc>960</ntasks_glc>
+	  <ntasks_wav>960</ntasks_wav>
+	  <ntasks_cpl>960</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>   
-	  <nthrds_lnd>4</nthrds_lnd>   
-	  <nthrds_rof>4</nthrds_rof> 
-	  <nthrds_ice>4</nthrds_ice> 
-	  <nthrds_ocn>4</nthrds_ocn> 
-	  <nthrds_glc>4</nthrds_glc> 
-	  <nthrds_wav>4</nthrds_wav> 
-	  <nthrds_cpl>4</nthrds_cpl> 
+	  <nthrds_atm>4</nthrds_atm>
+	  <nthrds_lnd>4</nthrds_lnd>
+	  <nthrds_rof>4</nthrds_rof>
+	  <nthrds_ice>4</nthrds_ice>
+	  <nthrds_ocn>4</nthrds_ocn>
+	  <nthrds_glc>4</nthrds_glc>
+	  <nthrds_wav>4</nthrds_wav>
+	  <nthrds_cpl>4</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>	
-	  <rootpe_lnd>0</rootpe_lnd>	
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
 	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>8640</rootpe_ice> 
+	  <rootpe_ice>8640</rootpe_ice>
 	  <rootpe_ocn>9600</rootpe_ocn>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>0</rootpe_wav>
@@ -599,23 +599,23 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>48</ntasks_atm> 
-	  <ntasks_lnd>8</ntasks_lnd> 
-	  <ntasks_rof>8</ntasks_rof>  
-	  <ntasks_ice>40</ntasks_ice> 
-	  <ntasks_ocn>32</ntasks_ocn> 
-	  <ntasks_cpl>48</ntasks_cpl> 
-	  <ntasks_glc>48</ntasks_glc> 
-	  <ntasks_wav>48</ntasks_wav> 
+	  <ntasks_atm>48</ntasks_atm>
+	  <ntasks_lnd>8</ntasks_lnd>
+	  <ntasks_rof>8</ntasks_rof>
+	  <ntasks_ice>40</ntasks_ice>
+	  <ntasks_ocn>32</ntasks_ocn>
+	  <ntasks_cpl>48</ntasks_cpl>
+	  <ntasks_glc>48</ntasks_glc>
+	  <ntasks_wav>48</ntasks_wav>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm> 
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_cpl>1</nthrds_cpl> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_cpl>1</nthrds_cpl>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -634,33 +634,33 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-64</ntasks_atm> 
-	  <ntasks_lnd>-16</ntasks_lnd>  
-	  <ntasks_rof>-16</ntasks_rof>  
-	  <ntasks_ice>-48</ntasks_ice>  
-	  <ntasks_cpl>-64</ntasks_cpl> 
-	  <ntasks_glc>-1</ntasks_glc> 
-	  <ntasks_wav>-1</ntasks_wav> 
-	  <ntasks_ocn>-16</ntasks_ocn>  
+	  <ntasks_atm>-64</ntasks_atm>
+	  <ntasks_lnd>-16</ntasks_lnd>
+	  <ntasks_rof>-16</ntasks_rof>
+	  <ntasks_ice>-48</ntasks_ice>
+	  <ntasks_cpl>-64</ntasks_cpl>
+	  <ntasks_glc>-1</ntasks_glc>
+	  <ntasks_wav>-1</ntasks_wav>
+	  <ntasks_ocn>-16</ntasks_ocn>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>8</nthrds_atm> 
-	  <nthrds_lnd>8</nthrds_lnd> 
-	  <nthrds_rof>8</nthrds_rof> 
-	  <nthrds_ice>8</nthrds_ice> 
-	  <nthrds_cpl>8</nthrds_cpl> 
-	  <nthrds_glc>8</nthrds_glc> 
-	  <nthrds_wav>8</nthrds_wav> 
-	  <nthrds_ocn>8</nthrds_ocn> 
+	  <nthrds_atm>8</nthrds_atm>
+	  <nthrds_lnd>8</nthrds_lnd>
+	  <nthrds_rof>8</nthrds_rof>
+	  <nthrds_ice>8</nthrds_ice>
+	  <nthrds_cpl>8</nthrds_cpl>
+	  <nthrds_glc>8</nthrds_glc>
+	  <nthrds_wav>8</nthrds_wav>
+	  <nthrds_ocn>8</nthrds_ocn>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
 	  <rootpe_ice>-16</rootpe_ice>
-	  <rootpe_cpl>0</rootpe_cpl> 
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
+	  <rootpe_cpl>0</rootpe_cpl>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
 	  <rootpe_ocn>-64</rootpe_ocn>
 	</rootpe>
       </pes>
@@ -671,24 +671,24 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>160</ntasks_atm> 
-	  <ntasks_lnd>80</ntasks_lnd> 
-	  <ntasks_rof>80</ntasks_rof>  
-	  <ntasks_ice>80</ntasks_ice> 
-	  <ntasks_cpl>160</ntasks_cpl> 
-	  <ntasks_glc>160</ntasks_glc> 
-	  <ntasks_wav>160</ntasks_wav> 
-	  <ntasks_ocn>240</ntasks_ocn> 
+	  <ntasks_atm>160</ntasks_atm>
+	  <ntasks_lnd>80</ntasks_lnd>
+	  <ntasks_rof>80</ntasks_rof>
+	  <ntasks_ice>80</ntasks_ice>
+	  <ntasks_cpl>160</ntasks_cpl>
+	  <ntasks_glc>160</ntasks_glc>
+	  <ntasks_wav>160</ntasks_wav>
+	  <ntasks_ocn>240</ntasks_ocn>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_cpl>2</nthrds_cpl> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_ocn>1</nthrds_ocn> 
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_cpl>2</nthrds_cpl>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_ocn>1</nthrds_ocn>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -707,24 +707,24 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>96</ntasks_atm> 
-	  <ntasks_lnd>48</ntasks_lnd> 
-	  <ntasks_rof>48</ntasks_rof>  
-	  <ntasks_ice>48</ntasks_ice> 
-	  <ntasks_ocn>12</ntasks_ocn> 
-	  <ntasks_cpl>96</ntasks_cpl> 
-	  <ntasks_glc>96</ntasks_glc> 
-	  <ntasks_wav>96</ntasks_wav> 
+	  <ntasks_atm>96</ntasks_atm>
+	  <ntasks_lnd>48</ntasks_lnd>
+	  <ntasks_rof>48</ntasks_rof>
+	  <ntasks_ice>48</ntasks_ice>
+	  <ntasks_ocn>12</ntasks_ocn>
+	  <ntasks_cpl>96</ntasks_cpl>
+	  <ntasks_glc>96</ntasks_glc>
+	  <ntasks_wav>96</ntasks_wav>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm> 
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_cpl>1</nthrds_cpl> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_cpl>1</nthrds_cpl>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -744,24 +744,24 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>192</ntasks_atm> 
-	  <ntasks_lnd>72</ntasks_lnd> 
-	  <ntasks_rof>72</ntasks_rof>  
-	  <ntasks_ice>120</ntasks_ice> 
-	  <ntasks_ocn>24</ntasks_ocn> 
-	  <ntasks_glc>192</ntasks_glc> 
-	  <ntasks_wav>192</ntasks_wav> 
-	  <ntasks_cpl>192</ntasks_cpl> 
+	  <ntasks_atm>192</ntasks_atm>
+	  <ntasks_lnd>72</ntasks_lnd>
+	  <ntasks_rof>72</ntasks_rof>
+	  <ntasks_ice>120</ntasks_ice>
+	  <ntasks_ocn>24</ntasks_ocn>
+	  <ntasks_glc>192</ntasks_glc>
+	  <ntasks_wav>192</ntasks_wav>
+	  <ntasks_cpl>192</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm> 
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -781,24 +781,24 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>256</ntasks_atm> 
-	  <ntasks_lnd>64</ntasks_lnd> 
-	  <ntasks_rof>64</ntasks_rof>  
-	  <ntasks_ice>192</ntasks_ice> 
-	  <ntasks_ocn>16</ntasks_ocn> 
-	  <ntasks_glc>256</ntasks_glc> 
-	  <ntasks_wav>256</ntasks_wav> 
-	  <ntasks_cpl>256</ntasks_cpl> 
+	  <ntasks_atm>256</ntasks_atm>
+	  <ntasks_lnd>64</ntasks_lnd>
+	  <ntasks_rof>64</ntasks_rof>
+	  <ntasks_ice>192</ntasks_ice>
+	  <ntasks_ocn>16</ntasks_ocn>
+	  <ntasks_glc>256</ntasks_glc>
+	  <ntasks_wav>256</ntasks_wav>
+	  <ntasks_cpl>256</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm> 
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -818,23 +818,23 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>240</ntasks_atm> 
-	  <ntasks_lnd>40</ntasks_lnd> 
-	  <ntasks_rof>40</ntasks_rof>  
-	  <ntasks_ice>200</ntasks_ice> 
-	  <ntasks_ocn>20</ntasks_ocn> 
-	  <ntasks_glc>240</ntasks_glc> 
-	  <ntasks_wav>240</ntasks_wav> 
-	  <ntasks_cpl>240</ntasks_cpl> 
+	  <ntasks_atm>240</ntasks_atm>
+	  <ntasks_lnd>40</ntasks_lnd>
+	  <ntasks_rof>40</ntasks_rof>
+	  <ntasks_ice>200</ntasks_ice>
+	  <ntasks_ocn>20</ntasks_ocn>
+	  <ntasks_glc>240</ntasks_glc>
+	  <ntasks_wav>240</ntasks_wav>
+	  <ntasks_cpl>240</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm> 
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -854,24 +854,24 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>120</ntasks_atm> 
-	  <ntasks_lnd>48</ntasks_lnd> 
-	  <ntasks_rof>48</ntasks_rof>  
-	  <ntasks_ice>72</ntasks_ice> 
-	  <ntasks_ocn>24</ntasks_ocn> 
-	  <ntasks_cpl>120</ntasks_cpl> 
-	  <ntasks_glc>1</ntasks_glc> 
-	  <ntasks_wav>1</ntasks_wav> 
+	  <ntasks_atm>120</ntasks_atm>
+	  <ntasks_lnd>48</ntasks_lnd>
+	  <ntasks_rof>48</ntasks_rof>
+	  <ntasks_ice>72</ntasks_ice>
+	  <ntasks_ocn>24</ntasks_ocn>
+	  <ntasks_cpl>120</ntasks_cpl>
+	  <ntasks_glc>1</ntasks_glc>
+	  <ntasks_wav>1</ntasks_wav>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm> 
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_cpl>1</nthrds_cpl> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_wav>1</nthrds_wav> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_cpl>1</nthrds_cpl>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_wav>1</nthrds_wav>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -891,24 +891,24 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-12</ntasks_atm> 
-	  <ntasks_lnd>-5</ntasks_lnd> 
-	  <ntasks_rof>-5</ntasks_rof> 
-	  <ntasks_ice>-7</ntasks_ice> 
-	  <ntasks_ocn>-2</ntasks_ocn> 
-	  <ntasks_glc>-1</ntasks_glc> 
-	  <ntasks_wav>-12</ntasks_wav> 
-	  <ntasks_cpl>-12</ntasks_cpl> 
+	  <ntasks_atm>-12</ntasks_atm>
+	  <ntasks_lnd>-5</ntasks_lnd>
+	  <ntasks_rof>-5</ntasks_rof>
+	  <ntasks_ice>-7</ntasks_ice>
+	  <ntasks_ocn>-2</ntasks_ocn>
+	  <ntasks_glc>-1</ntasks_glc>
+	  <ntasks_wav>-12</ntasks_wav>
+	  <ntasks_cpl>-12</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -928,24 +928,24 @@
       <pes pesize="any" compset="CAM.+CLM.+CICE.+POP">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>96</ntasks_atm> 
-	  <ntasks_lnd>96</ntasks_lnd> 
-	  <ntasks_rof>96</ntasks_rof> 
-	  <ntasks_ice>96</ntasks_ice> 
-	  <ntasks_ocn>96</ntasks_ocn> 
-	  <ntasks_glc>96</ntasks_glc> 
-	  <ntasks_wav>96</ntasks_wav> 
-	  <ntasks_cpl>96</ntasks_cpl> 
+	  <ntasks_atm>96</ntasks_atm>
+	  <ntasks_lnd>96</ntasks_lnd>
+	  <ntasks_rof>96</ntasks_rof>
+	  <ntasks_ice>96</ntasks_ice>
+	  <ntasks_ocn>96</ntasks_ocn>
+	  <ntasks_glc>96</ntasks_glc>
+	  <ntasks_wav>96</ntasks_wav>
+	  <ntasks_cpl>96</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>4</nthrds_atm> 
-	  <nthrds_lnd>4</nthrds_lnd> 
-	  <nthrds_rof>4</nthrds_rof> 
-	  <nthrds_ice>4</nthrds_ice> 
-	  <nthrds_ocn>4</nthrds_ocn> 
-	  <nthrds_glc>4</nthrds_glc> 
-	  <nthrds_wav>4</nthrds_wav> 
-	  <nthrds_cpl>4</nthrds_cpl> 
+	  <nthrds_atm>4</nthrds_atm>
+	  <nthrds_lnd>4</nthrds_lnd>
+	  <nthrds_rof>4</nthrds_rof>
+	  <nthrds_ice>4</nthrds_ice>
+	  <nthrds_ocn>4</nthrds_ocn>
+	  <nthrds_glc>4</nthrds_glc>
+	  <nthrds_wav>4</nthrds_wav>
+	  <nthrds_cpl>4</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -965,24 +965,24 @@
       <pes pesize="any" compset="CAM.+CLM.+CICE_DOCN%SOM">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>96</ntasks_atm> 
-	  <ntasks_lnd>96</ntasks_lnd> 
-	  <ntasks_rof>96</ntasks_rof> 
-	  <ntasks_ice>96</ntasks_ice> 
-	  <ntasks_ocn>96</ntasks_ocn> 
-	  <ntasks_glc>96</ntasks_glc> 
-	  <ntasks_wav>96</ntasks_wav> 
-	  <ntasks_cpl>96</ntasks_cpl> 
+	  <ntasks_atm>96</ntasks_atm>
+	  <ntasks_lnd>96</ntasks_lnd>
+	  <ntasks_rof>96</ntasks_rof>
+	  <ntasks_ice>96</ntasks_ice>
+	  <ntasks_ocn>96</ntasks_ocn>
+	  <ntasks_glc>96</ntasks_glc>
+	  <ntasks_wav>96</ntasks_wav>
+	  <ntasks_cpl>96</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>4</nthrds_atm> 
-	  <nthrds_lnd>4</nthrds_lnd> 
-	  <nthrds_rof>4</nthrds_rof> 
-	  <nthrds_ice>4</nthrds_ice> 
-	  <nthrds_ocn>4</nthrds_ocn> 
-	  <nthrds_glc>4</nthrds_glc> 
-	  <nthrds_wav>4</nthrds_wav> 
-	  <nthrds_cpl>4</nthrds_cpl> 
+	  <nthrds_atm>4</nthrds_atm>
+	  <nthrds_lnd>4</nthrds_lnd>
+	  <nthrds_rof>4</nthrds_rof>
+	  <nthrds_ice>4</nthrds_ice>
+	  <nthrds_ocn>4</nthrds_ocn>
+	  <nthrds_glc>4</nthrds_glc>
+	  <nthrds_wav>4</nthrds_wav>
+	  <nthrds_cpl>4</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -1002,24 +1002,24 @@
       <pes pesize="any" compset="CAM.+CLM.+CICE_DOCN%SOM">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>180</ntasks_atm> 
-	  <ntasks_lnd>180</ntasks_lnd> 
-	  <ntasks_rof>180</ntasks_rof> 
-	  <ntasks_ice>180</ntasks_ice> 
-	  <ntasks_ocn>180</ntasks_ocn> 
-	  <ntasks_glc>180</ntasks_glc> 
-	  <ntasks_wav>180</ntasks_wav> 
-	  <ntasks_cpl>180</ntasks_cpl> 
+	  <ntasks_atm>180</ntasks_atm>
+	  <ntasks_lnd>180</ntasks_lnd>
+	  <ntasks_rof>180</ntasks_rof>
+	  <ntasks_ice>180</ntasks_ice>
+	  <ntasks_ocn>180</ntasks_ocn>
+	  <ntasks_glc>180</ntasks_glc>
+	  <ntasks_wav>180</ntasks_wav>
+	  <ntasks_cpl>180</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -1039,34 +1039,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-8</ntasks_atm> 
-	  <ntasks_lnd>-4</ntasks_lnd>           
-	  <ntasks_rof>-4</ntasks_rof> 
-	  <ntasks_ice>-4</ntasks_ice> 
-	  <ntasks_ocn>-1</ntasks_ocn> 
-	  <ntasks_glc>-8</ntasks_glc> 
-	  <ntasks_wav>-8</ntasks_wav> 
-	  <ntasks_cpl>-8</ntasks_cpl> 
+	  <ntasks_atm>-8</ntasks_atm>
+	  <ntasks_lnd>-4</ntasks_lnd>
+	  <ntasks_rof>-4</ntasks_rof>
+	  <ntasks_ice>-4</ntasks_ice>
+	  <ntasks_ocn>-1</ntasks_ocn>
+	  <ntasks_glc>-8</ntasks_glc>
+	  <ntasks_wav>-8</ntasks_wav>
+	  <ntasks_cpl>-8</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>-4</rootpe_ice>    
-	  <rootpe_ocn>-8</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>-4</rootpe_ice>
+	  <rootpe_ocn>-8</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -1076,34 +1076,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-16</ntasks_atm> 
-	  <ntasks_lnd>-9</ntasks_lnd>           
-	  <ntasks_rof>-9</ntasks_rof> 
-	  <ntasks_ice>-7</ntasks_ice> 
-	  <ntasks_ocn>-1</ntasks_ocn> 
-	  <ntasks_glc>-1</ntasks_glc> 
-	  <ntasks_wav>-1</ntasks_wav> 
-	  <ntasks_cpl>-16</ntasks_cpl> 
+	  <ntasks_atm>-16</ntasks_atm>
+	  <ntasks_lnd>-9</ntasks_lnd>
+	  <ntasks_rof>-9</ntasks_rof>
+	  <ntasks_ice>-7</ntasks_ice>
+	  <ntasks_ocn>-1</ntasks_ocn>
+	  <ntasks_glc>-1</ntasks_glc>
+	  <ntasks_wav>-1</ntasks_wav>
+	  <ntasks_cpl>-16</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>                   
-	  <nthrds_lnd>8</nthrds_lnd> 
-	  <nthrds_rof>8</nthrds_rof> 
-	  <nthrds_ice>8</nthrds_ice> 
-	  <nthrds_ocn>8</nthrds_ocn> 
-	  <nthrds_glc>8</nthrds_glc> 
-	  <nthrds_wav>8</nthrds_wav> 
-	  <nthrds_cpl>8</nthrds_cpl> 
+	  <nthrds_atm>8</nthrds_atm>
+	  <nthrds_lnd>8</nthrds_lnd>
+	  <nthrds_rof>8</nthrds_rof>
+	  <nthrds_ice>8</nthrds_ice>
+	  <nthrds_ocn>8</nthrds_ocn>
+	  <nthrds_glc>8</nthrds_glc>
+	  <nthrds_wav>8</nthrds_wav>
+	  <nthrds_cpl>8</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>-9</rootpe_ice>    
-	  <rootpe_ocn>-16</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>-9</rootpe_ice>
+	  <rootpe_ocn>-16</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -1114,34 +1114,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>-208</ntasks_atm> 
-	  <ntasks_lnd>-32</ntasks_lnd>           
-	  <ntasks_rof>-32</ntasks_rof> 
-	  <ntasks_ice>-80</ntasks_ice> 
-	  <ntasks_ocn>-48</ntasks_ocn> 
-	  <ntasks_glc>-1</ntasks_glc> 
-	  <ntasks_wav>-1</ntasks_wav> 
-	  <ntasks_cpl>-208</ntasks_cpl> 
+	  <ntasks_atm>-208</ntasks_atm>
+	  <ntasks_lnd>-32</ntasks_lnd>
+	  <ntasks_rof>-32</ntasks_rof>
+	  <ntasks_ice>-80</ntasks_ice>
+	  <ntasks_ocn>-48</ntasks_ocn>
+	  <ntasks_glc>-1</ntasks_glc>
+	  <ntasks_wav>-1</ntasks_wav>
+	  <ntasks_cpl>-208</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>8</nthrds_atm>                   
-	  <nthrds_lnd>8</nthrds_lnd> 
-	  <nthrds_rof>8</nthrds_rof> 
-	  <nthrds_ice>8</nthrds_ice> 
-	  <nthrds_ocn>8</nthrds_ocn> 
-	  <nthrds_glc>8</nthrds_glc> 
-	  <nthrds_wav>8</nthrds_wav> 
-	  <nthrds_cpl>8</nthrds_cpl> 
+	  <nthrds_atm>8</nthrds_atm>
+	  <nthrds_lnd>8</nthrds_lnd>
+	  <nthrds_rof>8</nthrds_rof>
+	  <nthrds_ice>8</nthrds_ice>
+	  <nthrds_ocn>8</nthrds_ocn>
+	  <nthrds_glc>8</nthrds_glc>
+	  <nthrds_wav>8</nthrds_wav>
+	  <nthrds_cpl>8</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>-32</rootpe_rof> 
-	  <rootpe_ice>-64</rootpe_ice>    
-	  <rootpe_ocn>-208</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>-32</rootpe_rof>
+	  <rootpe_ice>-64</rootpe_ice>
+	  <rootpe_ocn>-208</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -1151,34 +1151,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>256</ntasks_atm>           
-	  <ntasks_lnd>256</ntasks_lnd>           
-	  <ntasks_rof>256</ntasks_rof> 
-	  <ntasks_ice>256</ntasks_ice> 
-	  <ntasks_ocn>256</ntasks_ocn> 
-	  <ntasks_glc>256</ntasks_glc> 
-	  <ntasks_wav>256</ntasks_wav> 
-	  <ntasks_cpl>256</ntasks_cpl> 
+	  <ntasks_atm>256</ntasks_atm>
+	  <ntasks_lnd>256</ntasks_lnd>
+	  <ntasks_rof>256</ntasks_rof>
+	  <ntasks_ice>256</ntasks_ice>
+	  <ntasks_ocn>256</ntasks_ocn>
+	  <ntasks_glc>256</ntasks_glc>
+	  <ntasks_wav>256</ntasks_wav>
+	  <ntasks_cpl>256</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -1188,24 +1188,24 @@
       <pes pesize="any" compset="CAM.+CLM.+CICE.+DOCN%SOM">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>240</ntasks_atm> 
-	  <ntasks_lnd>240</ntasks_lnd> 
-	  <ntasks_rof>240</ntasks_rof> 
-	  <ntasks_ice>240</ntasks_ice> 
-	  <ntasks_ocn>240</ntasks_ocn> 
-	  <ntasks_glc>240</ntasks_glc> 
-	  <ntasks_wav>240</ntasks_wav> 
-	  <ntasks_cpl>240</ntasks_cpl> 
+	  <ntasks_atm>240</ntasks_atm>
+	  <ntasks_lnd>240</ntasks_lnd>
+	  <ntasks_rof>240</ntasks_rof>
+	  <ntasks_ice>240</ntasks_ice>
+	  <ntasks_ocn>240</ntasks_ocn>
+	  <ntasks_glc>240</ntasks_glc>
+	  <ntasks_wav>240</ntasks_wav>
+	  <ntasks_cpl>240</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_cpl>2</nthrds_cpl> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_cpl>2</nthrds_cpl>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -1225,30 +1225,30 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>960</ntasks_atm> 
-	  <ntasks_lnd>48</ntasks_lnd>  
-	  <ntasks_rof>48</ntasks_rof>  
-	  <ntasks_ice>912</ntasks_ice> 
-	  <ntasks_ocn>48</ntasks_ocn>  
-	  <ntasks_glc>1</ntasks_glc>   
-	  <ntasks_wav>960</ntasks_wav>   
-	  <ntasks_cpl>960</ntasks_cpl> 
+	  <ntasks_atm>960</ntasks_atm>
+	  <ntasks_lnd>48</ntasks_lnd>
+	  <ntasks_rof>48</ntasks_rof>
+	  <ntasks_ice>912</ntasks_ice>
+	  <ntasks_ocn>48</ntasks_ocn>
+	  <ntasks_glc>1</ntasks_glc>
+	  <ntasks_wav>960</ntasks_wav>
+	  <ntasks_cpl>960</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>4</nthrds_atm> 
-	  <nthrds_lnd>4</nthrds_lnd> 
-	  <nthrds_rof>4</nthrds_rof> 
-	  <nthrds_ice>4</nthrds_ice> 
-	  <nthrds_ocn>4</nthrds_ocn> 
-	  <nthrds_glc>4</nthrds_glc> 
-	  <nthrds_wav>4</nthrds_wav> 
-	  <nthrds_cpl>4</nthrds_cpl> 
+	  <nthrds_atm>4</nthrds_atm>
+	  <nthrds_lnd>4</nthrds_lnd>
+	  <nthrds_rof>4</nthrds_rof>
+	  <nthrds_ice>4</nthrds_ice>
+	  <nthrds_ocn>4</nthrds_ocn>
+	  <nthrds_glc>4</nthrds_glc>
+	  <nthrds_wav>4</nthrds_wav>
+	  <nthrds_cpl>4</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
 	  <rootpe_lnd>0</rootpe_lnd>
 	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>48</rootpe_ice> 
+	  <rootpe_ice>48</rootpe_ice>
 	  <rootpe_ocn>960</rootpe_ocn>
 	  <rootpe_glc>0</rootpe_glc>
 	  <rootpe_wav>0</rootpe_wav>
@@ -1262,24 +1262,24 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>384</ntasks_atm> 
-	  <ntasks_lnd>64</ntasks_lnd> 
-	  <ntasks_rof>64</ntasks_rof>  
-	  <ntasks_ice>320</ntasks_ice> 
-	  <ntasks_ocn>32</ntasks_ocn> 
-	  <ntasks_glc>384</ntasks_glc> 
-	  <ntasks_wav>384</ntasks_wav> 
-	  <ntasks_cpl>64</ntasks_cpl> 
+	  <ntasks_atm>384</ntasks_atm>
+	  <ntasks_lnd>64</ntasks_lnd>
+	  <ntasks_rof>64</ntasks_rof>
+	  <ntasks_ice>320</ntasks_ice>
+	  <ntasks_ocn>32</ntasks_ocn>
+	  <ntasks_glc>384</ntasks_glc>
+	  <ntasks_wav>384</ntasks_wav>
+	  <ntasks_cpl>64</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>4</nthrds_atm> 
-	  <nthrds_lnd>4</nthrds_lnd> 
-	  <nthrds_rof>4</nthrds_rof> 
-	  <nthrds_ice>4</nthrds_ice> 
-	  <nthrds_ocn>4</nthrds_ocn> 
-	  <nthrds_glc>4</nthrds_glc> 
-	  <nthrds_wav>4</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>4</nthrds_atm>
+	  <nthrds_lnd>4</nthrds_lnd>
+	  <nthrds_rof>4</nthrds_rof>
+	  <nthrds_ice>4</nthrds_ice>
+	  <nthrds_ocn>4</nthrds_ocn>
+	  <nthrds_glc>4</nthrds_glc>
+	  <nthrds_wav>4</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -1299,24 +1299,24 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>300</ntasks_atm> 
-	  <ntasks_lnd>90</ntasks_lnd> 
-	  <ntasks_rof>90</ntasks_rof> 
-	  <ntasks_ice>210</ntasks_ice> 
-	  <ntasks_ocn>60</ntasks_ocn>  
-	  <ntasks_glc>300</ntasks_glc> 
+	  <ntasks_atm>300</ntasks_atm>
+	  <ntasks_lnd>90</ntasks_lnd>
+	  <ntasks_rof>90</ntasks_rof>
+	  <ntasks_ice>210</ntasks_ice>
+	  <ntasks_ocn>60</ntasks_ocn>
+	  <ntasks_glc>300</ntasks_glc>
 	  <ntasks_wav>300</ntasks_wav>
-	  <ntasks_cpl>300</ntasks_cpl> 
+	  <ntasks_cpl>300</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -1336,24 +1336,24 @@
       <pes pesize="any" compset="CAM5.+CLM.+CICE.+POP.+">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>600</ntasks_atm> 
-	  <ntasks_lnd>210</ntasks_lnd> 
-	  <ntasks_rof>210</ntasks_rof> 
-	  <ntasks_ice>390</ntasks_ice> 
-	  <ntasks_ocn>30</ntasks_ocn>  
-	  <ntasks_glc>600</ntasks_glc> 
-	  <ntasks_wav>600</ntasks_wav> 
-	  <ntasks_cpl>600</ntasks_cpl> 
+	  <ntasks_atm>600</ntasks_atm>
+	  <ntasks_lnd>210</ntasks_lnd>
+	  <ntasks_rof>210</ntasks_rof>
+	  <ntasks_ice>390</ntasks_ice>
+	  <ntasks_ocn>30</ntasks_ocn>
+	  <ntasks_glc>600</ntasks_glc>
+	  <ntasks_wav>600</ntasks_wav>
+	  <ntasks_cpl>600</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -1370,27 +1370,66 @@
   </grid>
   <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
     <mach name="yellowstone">
+      <pes pesize="X" compset="CAM5.+CLM.+CICE.+POP.+">
+	<PES_PER_NODE>16</PES_PER_NODE>
+	<MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>-108</ntasks_atm>
+	  <ntasks_lnd>-92</ntasks_lnd>
+	  <ntasks_rof>-92</ntasks_rof>
+	  <ntasks_ice>-16</ntasks_ice>
+	  <ntasks_ocn>-10</ntasks_ocn>
+	  <ntasks_glc>1</ntasks_glc>
+	  <ntasks_wav>1</ntasks_wav>
+	  <ntasks_cpl>-108</ntasks_cpl>
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>-92</rootpe_ice>
+	  <rootpe_ocn>-108</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
+    <mach name="yellowstone">
       <pes pesize="L" compset="CAM5">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>900</ntasks_atm> 
-	  <ntasks_lnd>300</ntasks_lnd> 
-	  <ntasks_rof>300</ntasks_rof> 
-	  <ntasks_ice>600</ntasks_ice> 
-	  <ntasks_ocn>90</ntasks_ocn>  
-	  <ntasks_glc>900</ntasks_glc> 
-	  <ntasks_wav>900</ntasks_wav> 
-	  <ntasks_cpl>900</ntasks_cpl> 
+	  <ntasks_atm>900</ntasks_atm>
+	  <ntasks_lnd>300</ntasks_lnd>
+	  <ntasks_rof>300</ntasks_rof>
+	  <ntasks_ice>600</ntasks_ice>
+	  <ntasks_ocn>90</ntasks_ocn>
+	  <ntasks_glc>900</ntasks_glc>
+	  <ntasks_wav>900</ntasks_wav>
+	  <ntasks_cpl>900</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -1410,24 +1449,24 @@
       <pes pesize="any" compset="BGC">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>300</ntasks_atm> 
-	  <ntasks_lnd>120</ntasks_lnd> 
-	  <ntasks_rof>120</ntasks_rof> 
-	  <ntasks_ice>180</ntasks_ice> 
-	  <ntasks_ocn>180</ntasks_ocn> 
-	  <ntasks_glc>300</ntasks_glc> 
-	  <ntasks_wav>300</ntasks_wav> 
-	  <ntasks_cpl>300</ntasks_cpl> 
+	  <ntasks_atm>300</ntasks_atm>
+	  <ntasks_lnd>120</ntasks_lnd>
+	  <ntasks_rof>120</ntasks_rof>
+	  <ntasks_ice>180</ntasks_ice>
+	  <ntasks_ocn>180</ntasks_ocn>
+	  <ntasks_glc>300</ntasks_glc>
+	  <ntasks_wav>300</ntasks_wav>
+	  <ntasks_cpl>300</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -1447,24 +1486,24 @@
       <pes pesize="any" compset="POP2%ECO.+BGC%BPRP">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>600</ntasks_atm> 
-	  <ntasks_lnd>210</ntasks_lnd> 
-	  <ntasks_rof>600</ntasks_rof> 
-	  <ntasks_ice>390</ntasks_ice> 
-	  <ntasks_ocn>120</ntasks_ocn> 
-	  <ntasks_glc>600</ntasks_glc> 
-	  <ntasks_wav>600</ntasks_wav> 
-	  <ntasks_cpl>600</ntasks_cpl> 
+	  <ntasks_atm>600</ntasks_atm>
+	  <ntasks_lnd>210</ntasks_lnd>
+	  <ntasks_rof>600</ntasks_rof>
+	  <ntasks_ice>390</ntasks_ice>
+	  <ntasks_ocn>120</ntasks_ocn>
+	  <ntasks_glc>600</ntasks_glc>
+	  <ntasks_wav>600</ntasks_wav>
+	  <ntasks_cpl>600</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -1484,24 +1523,24 @@
       <pes pesize="any" compset="CAM.+CLM.+CICE.+DOCN%SOM">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>192</ntasks_atm> 
-	  <ntasks_lnd>192</ntasks_lnd> 
-	  <ntasks_rof>192</ntasks_rof> 
-	  <ntasks_ice>192</ntasks_ice> 
-	  <ntasks_ocn>192</ntasks_ocn> 
-	  <ntasks_glc>192</ntasks_glc> 
-	  <ntasks_wav>192</ntasks_wav> 
-	  <ntasks_cpl>192</ntasks_cpl> 
+	  <ntasks_atm>192</ntasks_atm>
+	  <ntasks_lnd>192</ntasks_lnd>
+	  <ntasks_rof>192</ntasks_rof>
+	  <ntasks_ice>192</ntasks_ice>
+	  <ntasks_ocn>192</ntasks_ocn>
+	  <ntasks_glc>192</ntasks_glc>
+	  <ntasks_wav>192</ntasks_wav>
+	  <ntasks_cpl>192</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>4</nthrds_atm> 
-	  <nthrds_lnd>4</nthrds_lnd> 
-	  <nthrds_rof>4</nthrds_rof> 
-	  <nthrds_ice>4</nthrds_ice> 
-	  <nthrds_ocn>4</nthrds_ocn> 
-	  <nthrds_glc>4</nthrds_glc> 
-	  <nthrds_wav>4</nthrds_wav> 
-	  <nthrds_cpl>4</nthrds_cpl> 
+	  <nthrds_atm>4</nthrds_atm>
+	  <nthrds_lnd>4</nthrds_lnd>
+	  <nthrds_rof>4</nthrds_rof>
+	  <nthrds_ice>4</nthrds_ice>
+	  <nthrds_ocn>4</nthrds_ocn>
+	  <nthrds_glc>4</nthrds_glc>
+	  <nthrds_wav>4</nthrds_wav>
+	  <nthrds_cpl>4</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -1521,34 +1560,34 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>1024</ntasks_atm> 
-	  <ntasks_lnd>416</ntasks_lnd> 
-	  <ntasks_rof>1024</ntasks_rof> 
-	  <ntasks_ice>1024</ntasks_ice> 
-	  <ntasks_ocn>1024</ntasks_ocn> 
-	  <ntasks_glc>1024</ntasks_glc> 
-	  <ntasks_wav>1024</ntasks_wav> 
-	  <ntasks_cpl>1024</ntasks_cpl> 
+	  <ntasks_atm>1024</ntasks_atm>
+	  <ntasks_lnd>416</ntasks_lnd>
+	  <ntasks_rof>1024</ntasks_rof>
+	  <ntasks_ice>1024</ntasks_ice>
+	  <ntasks_ocn>1024</ntasks_ocn>
+	  <ntasks_glc>1024</ntasks_glc>
+	  <ntasks_wav>1024</ntasks_wav>
+	  <ntasks_cpl>1024</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd>
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
     </mach>
@@ -1558,24 +1597,24 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>15330</ntasks_atm> 
-	  <ntasks_lnd>5115</ntasks_lnd> 
-	  <ntasks_rof>5115</ntasks_rof> 
-	  <ntasks_ice>10215</ntasks_ice> 
-	  <ntasks_ocn>30</ntasks_ocn> 
-	  <ntasks_glc>15330</ntasks_glc> 
-	  <ntasks_wav>15330</ntasks_wav> 
-	  <ntasks_cpl>15330</ntasks_cpl> 
+	  <ntasks_atm>15330</ntasks_atm>
+	  <ntasks_lnd>5115</ntasks_lnd>
+	  <ntasks_rof>5115</ntasks_rof>
+	  <ntasks_ice>10215</ntasks_ice>
+	  <ntasks_ocn>30</ntasks_ocn>
+	  <ntasks_glc>15330</ntasks_glc>
+	  <ntasks_wav>15330</ntasks_wav>
+	  <ntasks_cpl>15330</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>1</nthrds_atm> 
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
+	  <nthrds_atm>1</nthrds_atm>
+	  <nthrds_lnd>1</nthrds_lnd>
+	  <nthrds_rof>1</nthrds_rof>
+	  <nthrds_ice>1</nthrds_ice>
+	  <nthrds_ocn>1</nthrds_ocn>
+	  <nthrds_glc>1</nthrds_glc>
+	  <nthrds_wav>1</nthrds_wav>
+	  <nthrds_cpl>1</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>
@@ -1595,24 +1634,24 @@
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
-	  <ntasks_atm>3200</ntasks_atm> 
-	  <ntasks_lnd>1600</ntasks_lnd> 
-	  <ntasks_rof>1600</ntasks_rof> 
-	  <ntasks_ice>1600</ntasks_ice> 
-	  <ntasks_ocn>32</ntasks_ocn> 
-	  <ntasks_glc>3200</ntasks_glc> 
-	  <ntasks_wav>3200</ntasks_wav> 
-	  <ntasks_cpl>3200</ntasks_cpl> 
+	  <ntasks_atm>3200</ntasks_atm>
+	  <ntasks_lnd>1600</ntasks_lnd>
+	  <ntasks_rof>1600</ntasks_rof>
+	  <ntasks_ice>1600</ntasks_ice>
+	  <ntasks_ocn>32</ntasks_ocn>
+	  <ntasks_glc>3200</ntasks_glc>
+	  <ntasks_wav>3200</ntasks_wav>
+	  <ntasks_cpl>3200</ntasks_cpl>
 	</ntasks>
 	<nthrds>
-	  <nthrds_atm>2</nthrds_atm> 
-	  <nthrds_lnd>2</nthrds_lnd> 
-	  <nthrds_rof>2</nthrds_rof> 
-	  <nthrds_ice>2</nthrds_ice> 
-	  <nthrds_ocn>2</nthrds_ocn> 
-	  <nthrds_glc>2</nthrds_glc> 
-	  <nthrds_wav>2</nthrds_wav> 
-	  <nthrds_cpl>2</nthrds_cpl> 
+	  <nthrds_atm>2</nthrds_atm>
+	  <nthrds_lnd>2</nthrds_lnd>
+	  <nthrds_rof>2</nthrds_rof>
+	  <nthrds_ice>2</nthrds_ice>
+	  <nthrds_ocn>2</nthrds_ocn>
+	  <nthrds_glc>2</nthrds_glc>
+	  <nthrds_wav>2</nthrds_wav>
+	  <nthrds_cpl>2</nthrds_cpl>
 	</nthrds>
 	<rootpe>
 	  <rootpe_atm>0</rootpe_atm>

--- a/cime_config/cesm/allactive/usermods_dirs/b1850/shell_commands
+++ b/cime_config/cesm/allactive/usermods_dirs/b1850/shell_commands
@@ -1,2 +1,2 @@
-
+./xmlchange OCN_CHL_TYPE=diagnostic
 

--- a/cime_config/cesm/allactive/usermods_dirs/b1850/user_nl_cice
+++ b/cime_config/cesm/allactive/usermods_dirs/b1850/user_nl_cice
@@ -1,0 +1,1 @@
+ice_ic = 'b.e15.B1850G.f09_g16.pi_control.25.cice.r.0041-01-01-00000.nc'

--- a/cime_config/cesm/allactive/usermods_dirs/b1850/user_nl_clm
+++ b/cime_config/cesm/allactive/usermods_dirs/b1850/user_nl_clm
@@ -1,0 +1,6 @@
+fsurdat = '/glade/p/cesmdata/cseg/inputdata/lnd/clm2/surfdata_map/surfdata_0.9x1.25_16pftsmodwshrubwglcr_simyr1850_c151210.nc'
+use_init_interp = .true.
+init_interp_fill_missing_with_natveg = .true.
+finidat = '/glade/scratch/hannay/land_ic/b.e15.B1850.f09_g16.pi_control.35_ic.clm2.r.0001-01-06-00000.nc'
+
+

--- a/cime_config/cesm/allactive/usermods_dirs/b1850/user_nl_cpl
+++ b/cime_config/cesm/allactive/usermods_dirs/b1850/user_nl_cpl
@@ -1,0 +1,2 @@
+flux_diurnal=.true.
+

--- a/cime_config/cesm/allactive/usermods_dirs/b1850/user_nl_pop
+++ b/cime_config/cesm/allactive/usermods_dirs/b1850/user_nl_pop
@@ -1,0 +1,16 @@
+alk_riv_flux_input%filename = '/glade/p/cesm/bgcwg/forcing/BEC_gx1v6_forcing_no_ms/river_nutrients_GNEWS2000_gx1v6_no_ms_c150702.nc'
+dfe_riv_flux_input%filename = '/glade/p/cesm/bgcwg/forcing/BEC_gx1v6_forcing_no_ms/river_nutrients_GNEWS2000_gx1v6_no_ms_c150702.nc'
+dic_riv_flux_input%filename = '/glade/p/cesm/bgcwg/forcing/BEC_gx1v6_forcing_no_ms/river_nutrients_GNEWS2000_gx1v6_no_ms_c150702.nc'
+din_riv_flux_input%filename = '/glade/p/cesm/bgcwg/forcing/BEC_gx1v6_forcing_no_ms/river_nutrients_GNEWS2000_gx1v6_no_ms_c150702.nc'
+dip_riv_flux_input%filename = '/glade/p/cesm/bgcwg/forcing/BEC_gx1v6_forcing_no_ms/river_nutrients_GNEWS2000_gx1v6_no_ms_c150702.nc'
+doc_riv_flux_input%filename = '/glade/p/cesm/bgcwg/forcing/BEC_gx1v6_forcing_no_ms/river_nutrients_GNEWS2000_gx1v6_no_ms_c150702.nc'
+don_riv_flux_input%filename = '/glade/p/cesm/bgcwg/forcing/BEC_gx1v6_forcing_no_ms/river_nutrients_GNEWS2000_gx1v6_no_ms_c150702.nc'
+dop_riv_flux_input%filename = '/glade/p/cesm/bgcwg/forcing/BEC_gx1v6_forcing_no_ms/river_nutrients_GNEWS2000_gx1v6_no_ms_c150702.nc'
+dsi_riv_flux_input%filename = '/glade/p/cesm/bgcwg/forcing/BEC_gx1v6_forcing_no_ms/river_nutrients_GNEWS2000_gx1v6_no_ms_c150702.nc'
+dust_flux_input%filename = '/glade/p/cesm/bgcwg/forcing/BEC_gx1v6_forcing_no_ms/dst79gnx_gx1v6_090416_no_ms_c150702.nc'
+fesedflux_input%filename = '/glade/p/cesm/bgcwg/forcing/BEC_gx1v6_forcing_no_ms/fesedflux_gx1v6_etopo2v2_Nov2015_vents_no_ms_c151218.nc'
+iron_flux_input%filename = '/glade/p/cesm/bgcwg/forcing/BEC_gx1v6_forcing_no_ms/solFe_scenario4_current_gx1v6_no_ms_c150702.nc'
+nhy_flux_monthly_input%filename = '/glade/p/cesm/bgcwg/forcing/BEC_gx1v6_forcing_no_ms/ndep_ocn_1850_gx1v6_no_ms_c150702.nc'
+nox_flux_monthly_input%filename = '/glade/p/cesm/bgcwg/forcing/BEC_gx1v6_forcing_no_ms/ndep_ocn_1850_gx1v6_no_ms_c150702.nc'
+
+

--- a/cime_config/cesm/config_grids.xml
+++ b/cime_config/cesm/config_grids.xml
@@ -6,17 +6,17 @@
     =========================================
     GRID naming convention
     =========================================
-    The long grid name has the order atm,lnd,ocn/ice,river,mask,glc 
+    The long grid name has the order atm,lnd,ocn/ice,river,mask,glc
     The following shortname is used
     a% => atm, l% => lnd, oi% => ocn/ice, r% => river, m% => mask, g% => glc, w% => wav
-    The notation is 
+    The notation is
     a%name_l%name_oi%name_r%name_m%mask_g%name_w%name
     Each grid is associated with three required elements and one optional element
     longname      (a%name_l%name_oi%name_r%name_m%mask_g%name_w%name)
     shortname     (for backwards compatibility)
     alias         (even shorter notation than shortname) (optional)
     support       (Description of the support level for this grid) (optional)
-    Each grid can also be associated with the following optional attributes	 
+    Each grid can also be associated with the following optional attributes
     compset       (Regular expression for compsets that are required to match for this grid) (optional)
   </help>
 
@@ -102,13 +102,13 @@
       <sname>T85_0.9x1.25_tx0.1v2</sname>
       <alias>T85_f09_t12</alias>
       <lname>a%T85_l%0.9x1.25_oi%tx0.1v2_r%r05_m%tx0.1v2_g%null_w%null</lname>
-    </grid> 
+    </grid>
 
     <grid>
       <sname>T341_0.23x0.31_tx0.1v2</sname>
       <alias>T341_f02_t12</alias>
       <lname>a%T341_l%0.23x0.31_oi%tx0.1v2_r%r05_m%tx0.1v2_g%null_w%null</lname>
-    </grid> 
+    </grid>
 
     <grid compset="(DOCN|XOCN|SOCN).+SGLC">
       <sname>T31_T31</sname>
@@ -138,7 +138,7 @@
       <sname>T62_gx3v7</sname>
       <alias>T62_g37</alias>
       <lname>a%T62_l%T62_oi%gx3v7_r%rx1_m%gx3v7_g%null_w%null</lname>
-    </grid>  
+    </grid>
 
     <grid compset="(DATM|XATM|SATM)">
       <sname>T62_tx1v1</sname>
@@ -188,7 +188,7 @@
       <sname>0.47x0.63_tx0.1v2</sname>
       <alias>f05_t12</alias>
       <lname>a%0.47x0.63_l%0.47x0.63_oi%tx0.1v2_r%r05_m%tx0.1v2_g%null_w%null</lname>
-    </grid>    
+    </grid>
 
     <grid>
       <sname>0.9x1.25_gx1v6</sname>
@@ -319,14 +319,14 @@
       <alias>ne30_f19_g16</alias>
       <lname>a%ne30np4_l%1.9x2.5_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null</lname>
       <support>For testing tri-grid</support>
-    </grid>  
+    </grid>
 
     <grid>
       <sname>ne30np4_0.9x1.25_gx1v6</sname>
       <alias>ne30_f09_g16</alias>
       <lname>a%ne30np4_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null</lname>
       <support>For testing tri-grid</support>
-    </grid> 
+    </grid>
 
     <grid>
       <sname>ne60np4_gx1v6</sname>
@@ -361,39 +361,39 @@
 
     <grid compset="(DOCN|XOCN|SOCN|AQUAP)">
       <sname>ne16np4_ne16np4</sname>
-      <alias>ne16_ne16</alias>    
+      <alias>ne16_ne16</alias>
       <lname>a%ne16np4_l%ne16np4_oi%ne16np4_r%r05_m%gx3v7_g%null_w%null</lname>
     </grid>
 
     <grid compset="(DOCN|XOCN|SOCN|AQUAP)">
       <sname>ne30np4_ne30np4</sname>
-      <alias>ne30_ne30</alias>    
+      <alias>ne30_ne30</alias>
       <lname>a%ne30np4_l%ne30np4_oi%ne30np4_r%r05_m%gx1v6_g%null_w%null</lname>
     </grid>
 
     <grid compset="(DOCN|XOCN|SOCN|AQUAP)">
       <sname>ne60np4_ne60np4</sname>
-      <alias>ne60_ne60</alias>    
+      <alias>ne60_ne60</alias>
       <lname>a%ne60np4_l%ne60np4_oi%ne60np4_r%r05_m%gx1v6_g%null_w%null</lname>
     </grid>
 
     <grid compset="(DOCN|XOCN|SOCN|AQUAP)">
       <sname>ne120np4_ne120np4</sname>
-      <alias>ne120_ne120</alias>  
+      <alias>ne120_ne120</alias>
       <lname>a%ne120np4_l%ne120np4_oi%ne120np4_r%r05_m%gx1v6_g%null_w%null</lname>
     </grid>
 
     <grid compset="(DOCN|XOCN|SOCN|AQUAP)">
       <sname>ne240np4_ne240np4</sname>
-      <alias>ne240_ne240</alias>  
+      <alias>ne240_ne240</alias>
       <lname>a%ne240np4_l%ne240np4_oi%ne240np4_r%null_m%gx1v6_g%null_w%null</lname>
     </grid>
 
-    <!--- cism grids --> 
+    <!--- cism grids -->
 
     <grid compset="_CISM">
       <sname>0.9x1.25_gx1v6_gland4</sname>
-      <alias>f09_g16_gl4</alias> 
+      <alias>f09_g16_gl4</alias>
       <lname>a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland4_w%null</lname>
     </grid>
 
@@ -505,7 +505,7 @@
       <sname>ne30np4_1.9x2.5_gx1v6_rx1</sname>
       <alias>ne30_f19_g16_rx1</alias>
       <lname>a%ne30np4_l%1.9x2.5_oi%gx1v6_r%rx1_m%gx1v6_g%null_w%null</lname>
-    </grid><!-- back compat --> 
+    </grid><!-- back compat -->
 
     <!-- ww3 grids -->
 
@@ -536,7 +536,7 @@
     </grid>
 
     <grid compset="(_DROF.*_DWAV|_DROF.*_WW3)">
-      <sname>1.9x2.5_gx1v6_rx1_ww3a</sname>  
+      <sname>1.9x2.5_gx1v6_rx1_ww3a</sname>
       <alias>f19_g16_rx1_ww3</alias>
       <lname>a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%rx1_m%gx1v6_g%null_w%ww3a</lname>
     </grid>
@@ -573,7 +573,7 @@
 
     <domain name="null">
       <!-- null grid -->
-      <nx>0</nx> <ny>0</ny>    
+      <nx>0</nx> <ny>0</ny>
       <desc>null is no grid: </desc>
     </domain>
 
@@ -584,170 +584,170 @@
       <desc>01col is a single-column grid for datm and POP:</desc>
     </domain>
 
-    <domain name="CLM_USRDAT">  
-      <nx>1</nx> <ny>1</ny> 
+    <domain name="CLM_USRDAT">
+      <nx>1</nx> <ny>1</ny>
       <file lnd_mask="reg">domain.lnd.${CLM_USRDAT_NAME}_navy.nc</file>
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>  
-      <desc>user specified domain - only valid for DATM/CLM compset</desc>  
+      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <desc>user specified domain - only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_numaIA">
-      <nx>1</nx> <ny>1</ny>  
-      <file lnd_mask="reg">domain.lnd.1x1pt-numaIA_navy.110106.nc</file>  
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>  
-      <desc>1x1 Numa Iowa -- only valid for DATM/CLM compset</desc>  
+      <nx>1</nx> <ny>1</ny>
+      <file lnd_mask="reg">domain.lnd.1x1pt-numaIA_navy.110106.nc</file>
+      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <desc>1x1 Numa Iowa -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_brazil">
-      <nx>1</nx> <ny>1</ny>  
-      <file lnd_mask="reg">domain.lnd.1x1pt-brazil_navy.090715.nc</file>  
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>  
-      <desc>1x1 Brazil -- only valid for DATM/CLM compset</desc>  
+      <nx>1</nx> <ny>1</ny>
+      <file lnd_mask="reg">domain.lnd.1x1pt-brazil_navy.090715.nc</file>
+      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <desc>1x1 Brazil -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_smallvilleIA">
-      <nx>1</nx> <ny>1</ny>  
-      <file lnd_mask="reg">domain.lnd.1x1pt-smallvilleIA_test.110106.nc</file>  
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>  
-      <desc>1x1 Smallville Iowa Crop Test Case -- only valid for DATM/CLM compset</desc>  
+      <nx>1</nx> <ny>1</ny>
+      <file lnd_mask="reg">domain.lnd.1x1pt-smallvilleIA_test.110106.nc</file>
+      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <desc>1x1 Smallville Iowa Crop Test Case -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_camdenNJ">
-      <nx>1</nx> <ny>1</ny>  
-      <file lnd_mask="reg">domain.lnd.1x1pt-camdenNJ_navy.111004.nc</file>  
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>  
-      <desc>1x1 Camden New Jersey -- only valid for DATM/CLM compset</desc>  
+      <nx>1</nx> <ny>1</ny>
+      <file lnd_mask="reg">domain.lnd.1x1pt-camdenNJ_navy.111004.nc</file>
+      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <desc>1x1 Camden New Jersey -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_mexicocityMEX">
-      <nx>1</nx> <ny>1</ny>  
+      <nx>1</nx> <ny>1</ny>
       <file lnd_mask="reg">domain.lnd.1x1pt-mexicocityMEX_navy.090715.nc</file>
       <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <desc>1x1 Mexico City Mexico -- only valid for DATM/CLM compset</desc>  
+      <desc>1x1 Mexico City Mexico -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_vancouverCAN">
-      <nx>1</nx> <ny>1</ny>  
-      <file lnd_mask="reg">domain.lnd.1x1pt-vancouverCAN_navy.090715.nc</file>  
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>  
-      <desc>1x1 Vancouver Canada -- only valid for DATM/CLM compset</desc>  
+      <nx>1</nx> <ny>1</ny>
+      <file lnd_mask="reg">domain.lnd.1x1pt-vancouverCAN_navy.090715.nc</file>
+      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <desc>1x1 Vancouver Canada -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_tropicAtl">
-      <nx>1</nx> <ny>1</ny>  
-      <file lnd_mask="reg">domain.lnd.1x1pt-tropicAtl_test.111004.nc</file>  
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>  
-      <desc>1x1 Tropical Atlantic Test Case -- only valid for DATM/CLM compset</desc>  
+      <nx>1</nx> <ny>1</ny>
+      <file lnd_mask="reg">domain.lnd.1x1pt-tropicAtl_test.111004.nc</file>
+      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <desc>1x1 Tropical Atlantic Test Case -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_urbanc_alpha">
-      <nx>1</nx> <ny>1</ny>  
-      <file lnd_mask="reg">domain.lnd.1x1pt-urbanc_alpha_test.110201.nc</file>  
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>  
-      <desc>1x1 Urban C Alpha Test Case -- only valid for DATM/CLM compset</desc>  
+      <nx>1</nx> <ny>1</ny>
+      <file lnd_mask="reg">domain.lnd.1x1pt-urbanc_alpha_test.110201.nc</file>
+      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <desc>1x1 Urban C Alpha Test Case -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="5x5_amazon">
-      <nx>1</nx> <ny>1</ny>  
-      <file lnd_mask="reg">domain.lnd.5x5pt-amazon_navy.090715.nc</file>  
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>  
-      <desc>5x5 Amazon regional case -- only valid for DATM/CLM compset</desc>  
+      <nx>1</nx> <ny>1</ny>
+      <file lnd_mask="reg">domain.lnd.5x5pt-amazon_navy.090715.nc</file>
+      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <desc>5x5 Amazon regional case -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="360x720cru">
       <nx>720</nx> <ny>360</ny>
-      <file lnd_mask="360x720cru">domain.lnd.360x720_cruncep.100429.nc</file>  
+      <file lnd_mask="360x720cru">domain.lnd.360x720_cruncep.100429.nc</file>
       <path lnd_mask="360x720cru">$DIN_LOC_ROOT/share/domains/domain.clm</path>
       <desc>Exact half-degree CRUNCEP datm forcing grid with CRUNCEP land-mask -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="0.23x0.31">
-      <nx>1152</nx> <ny>768</ny>  
+      <nx>1152</nx> <ny>768</ny>
       <file lnd_mask="gx1v6">domain.lnd.fv0.23x0.31_gx1v6.100517.nc</file>
       <file ocn_mask="gx1v6">domain.ocn.0.23x0.31_gx1v6_101108.nc</file>
       <file lnd_mask="tx0.1v2">domain.lnd.fv0.23x0.31_tx0.1v2_070929.nc</file>
       <!-- BUG: missing ocn domain file for tx01.v2 mask -->
-      <desc>0.23x0.31 is FV 1/4-deg grid:</desc> 
+      <desc>0.23x0.31 is FV 1/4-deg grid:</desc>
     </domain>
 
     <domain name="0.47x0.63">
-      <nx>576</nx>  <ny>384</ny>  
+      <nx>576</nx>  <ny>384</ny>
       <file lnd_mask="gx1v6">domain.lnd.fv0.47x0.63_gx1v6.090407.nc</file>
       <file ocn_mask="gx1v6">domain.ocn.0.47x0.63_gx1v6_090408.nc</file>
       <file lnd_mask="tx0.1v2">domain.lnd.fv0.47x0.63_tx0.1v2_070929.nc</file>
       <!-- BUG: missing ocn domain file for tx01.v2 mask -->
-      <desc>0.47x0.63 is FV 1/2-deg grid:</desc> 
+      <desc>0.47x0.63 is FV 1/2-deg grid:</desc>
     </domain>
 
     <domain name="0.9x1.25">
-      <nx>288</nx>  <ny>192</ny>  
+      <nx>288</nx>  <ny>192</ny>
       <file lnd_mask="gx1v6">domain.lnd.fv0.9x1.25_gx1v6.090309.nc</file>
       <file ocn_mask="gx1v6">domain.ocn.0.9x1.25_gx1v6_090403.nc</file>
       <file lnd_mask="mp120v1">domain.lnd.fv0.9x1.25_mp120v1.111018.nc</file>
       <file lnd_mask="tx0.1v2">domain.lnd.fv0.9x1.25_tx0.1v2_070928.nc</file>
       <!-- BUG: missing ocn domain file for mp120v1 and tx01.v2 mask -->
-      <desc>0.9x1.25 is FV 1-deg grid:</desc> 
+      <desc>0.9x1.25 is FV 1-deg grid:</desc>
     </domain>
 
     <domain name="1.9x2.5">
-      <nx>144</nx>  <ny>96</ny>   
+      <nx>144</nx>  <ny>96</ny>
       <file lnd_mask="gx1v6">domain.lnd.fv1.9x2.5_gx1v6.090206.nc</file>
       <file ocn_mask="gx1v6">domain.ocn.1.9x2.5_gx1v6_090403.nc</file>
       <file lnd_mask="tx1v1">domain.lnd.fv1.9x2.5_tx1v1_090713.nc</file>
-      <desc>1.9x2.5 is FV 2-deg grid:</desc> 
+      <desc>1.9x2.5 is FV 2-deg grid:</desc>
     </domain>
 
     <domain name="4x5">
-      <nx>72</nx> <ny>46</ny>   
+      <nx>72</nx> <ny>46</ny>
       <file lnd_mask="gx3v7">domain.lnd.fv4x5_gx3v7.091218.nc</file>
       <file ocn_mask="gx3v7">domain.ocn.4x5_gx3v7_100120.nc</file>
-      <desc>4x5 is FV 4-deg grid:</desc> 
+      <desc>4x5 is FV 4-deg grid:</desc>
     </domain>
 
     <domain name="2.5x3.33">
-      <nx>108</nx>  <ny>72</ny>   
+      <nx>108</nx>  <ny>72</ny>
       <file lnd_mask="gx3v7">domain.lnd.fv2.5x3.33_gx3v7.110223.nc</file>
       <file ocn_mask="gx3v7">domain.ocn.fv2.5x3.33_gx3v7_110223.nc</file>
-      <desc>2.5x3.33 is FV 3-deg grid:</desc> 
+      <desc>2.5x3.33 is FV 3-deg grid:</desc>
     </domain>
 
-    <domain name="10x15">       
-      <nx>24</nx>   <ny>19</ny>   
+    <domain name="10x15">
+      <nx>24</nx>   <ny>19</ny>
       <file lnd_mask="usgs">domain.lnd.fv10x15_USGS.110713.nc</file>
       <file ocn_mask="usgs">domain.camocn.10x15_USGS_070807.nc</file>
       <path lnd_mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm</path>
       <path ocn_mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <desc>10x15 is FV 10-deg grid:</desc> 
+      <desc>10x15 is FV 10-deg grid:</desc>
       <support>For low resolution testing</support>
     </domain>
 
-    <domain name="T341"> 
-      <nx>1024</nx> <ny>512</ny> 
+    <domain name="T341">
+      <nx>1024</nx> <ny>512</ny>
       <!-- global spectral (eulerian dycore) grids-->
       <!--- mask for atm is irrelevant -->
       <file lnd_mask="tx0.1v2">domain.lnd.T341_gx1v6.111226.nc</file>
-      <desc>T341 is Gaussian grid:</desc> 
+      <desc>T341 is Gaussian grid:</desc>
       <support>Backward compatible for very high resolution Spectral-dycore experiments</support>
     </domain>
 
     <domain name="T85">
       <!-- global spectral (eulerian dycore) grids-->
-      <nx>256</nx>  <ny>128</ny> 
+      <nx>256</nx>  <ny>128</ny>
       <file lnd_mask="gx1v6">domain.lnd.T85_gx1v4.060403.nc</file>
       <file lnd_mask="tx0.1v2">domain.lnd.T85_gx1v4.060403.nc</file>
-      <desc>T85 is Gaussian grid:</desc> 
+      <desc>T85 is Gaussian grid:</desc>
       <support>Backward compatible for high resolution Spectral-dycore experiments</support>
     </domain>
 
-    <domain name="T62">                   
-      <nx>192</nx>  <ny>96</ny>  
+    <domain name="T62">
+      <nx>192</nx>  <ny>96</ny>
       <!--- datm/slnd/drof only -->
       <file lnd_mask="gx1v6">domain.lnd.T62_gx1v6.090320.nc</file>
       <file lnd_mask="gx3v7">domain.lnd.T62_gx3v7.090911.nc</file>
       <file lnd_mask="tx1v1">domain.lnd.T62_tx1v1.090122.nc</file>
       <file lnd_mask="tx0.1v2">domain.lnd.T62_tx0.1v2_090623.nc</file>
       <file lnd_mask="mpas120">domain.lnd.T62_mpas120.121116.nc</file>
-      <desc>T62 is Gaussian grid:</desc> 
+      <desc>T62 is Gaussian grid:</desc>
     </domain>
 
     <domain name="T42">
@@ -756,113 +756,113 @@
       <file ocn_mask="usgs">domain.camocn.64x128_USGS_070807.nc</file>
       <path lnd_mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm</path>
       <path ocn_mask="usgs">$DIN_LOC_ROOT/atm/cam/ocnfrac</path>
-      <desc>T42 is Gaussian grid:</desc> 
+      <desc>T42 is Gaussian grid:</desc>
     </domain>
 
     <domain name="T31">
       <nx>96</nx> <ny>48</ny>
       <file lnd_mask="gx3v7">domain.lnd.T31_gx3v7.090928.nc</file>
       <file ocn_mask="gx3v7">domain.ocn.48x96_gx3v7_100114.nc</file>
-      <desc>T31 is Gaussian grid:</desc> 
+      <desc>T31 is Gaussian grid:</desc>
     </domain>
 
     <domain name="ne16np4">
-      <nx>13826</nx> <ny>1</ny>   
+      <nx>13826</nx> <ny>1</ny>
       <file lnd_mask="gx3v7">domain.lnd.ne16np4_gx3v7.120406.nc</file>
       <file ocn_mask="gx3v7">domain.ocn.ne16np4_gx3v7.121113.nc</file>
-      <desc>ne16np4 is Spectral Elem 2-deg grid:</desc> 
+      <desc>ne16np4 is Spectral Elem 2-deg grid:</desc>
       <support>For low resolution spectral element grid testing</support>
     </domain>
 
     <domain name="ne30np4">
-      <nx>48602</nx> <ny>1</ny>   
+      <nx>48602</nx> <ny>1</ny>
       <file lnd_mask="gx1v6">domain.lnd.ne30np4_gx1v6.110905.nc</file>
       <file ocn_mask="gx1v6">domain.ocn.ne30np4_gx1v6_110217.nc</file>
-      <desc>ne30np4 is Spectral Elem 1-deg grid:</desc> 
+      <desc>ne30np4 is Spectral Elem 1-deg grid:</desc>
     </domain>
 
     <domain name="ne60np4">
-      <nx>194402</nx> <ny>1</ny>   
+      <nx>194402</nx> <ny>1</ny>
       <file lnd_mask="gx1v6">domain.lnd.ne60np4_gx1v6.120406.nc</file>
       <file ocn_mask="gx1v6">domain.ocn.ne60np4_gx1v6.121113.nc</file>
-      <desc>ne60np4 is Spectral Elem 1/2-deg grid:</desc> 
+      <desc>ne60np4 is Spectral Elem 1/2-deg grid:</desc>
     </domain>
 
     <domain name="ne120np4">
-      <nx>777602</nx> <ny>1</ny>   
+      <nx>777602</nx> <ny>1</ny>
       <file lnd_mask="gx1v6">domain.lnd.ne120np4_gx1v6.110502.nc</file>
       <file ocn_mask="gx1v6">domain.ocn.ne120np4_gx1v6.121113.nc</file>
       <file lnd_mask="tx0.1v2">domain.lnd.ne120np4_tx01v2.120412.nc</file>
-      <desc>ne120np4 is Spectral Elem 1/4-deg grid:</desc> 
+      <desc>ne120np4 is Spectral Elem 1/4-deg grid:</desc>
     </domain>
 
     <domain name="ne240np4">
-      <nx>3110402</nx> <ny>1</ny>   
+      <nx>3110402</nx> <ny>1</ny>
       <file lnd_mask="gx1v6">domain.lnd.ne240np4_gx1v6.111226.nc</file>
       <file ocn_mask="gx1v6">domain.ocn.ne240np4_gx1v6.111226.nc</file>
-      <desc>ne240np4 is Spectral Elem 1/8-deg grid:</desc> 
+      <desc>ne240np4 is Spectral Elem 1/8-deg grid:</desc>
       <support>Experimental for very high resolution experiments</support>
     </domain>
 
     <domain name="gx1v6">
-      <nx>320</nx>  <ny>384</ny>  
+      <nx>320</nx>  <ny>384</ny>
       <file lnd_mask="gx1v6">domain.ocn.gx1v6.090206.nc </file>
       <file ocn_mask="gx1v6">domain.ocn.gx1v6.090206.nc </file>
       <desc>gx1v6 is displaced Greenland pole v6 1-deg grid:</desc>
     </domain>
 
     <domain name="gx3v7">
-      <nx>100</nx> <ny>116</ny>  
+      <nx>100</nx> <ny>116</ny>
       <file ocn_mask="gx3v7">domain.ocn.gx3v7.120323.nc </file>
       <desc>gx3v7 is displaced Greenland pole v7 3-deg grid:</desc>
     </domain>
 
     <domain name="tx0.1v2">
-      <nx>3600</nx> <ny>2400</ny> 
+      <nx>3600</nx> <ny>2400</ny>
       <file ocn_mask="tx0.1v2">domain.ocn.tx0.1v2_090218.nc</file>
       <desc>tx0.1v2 is tripole v2 1/10-deg grid:</desc>
       <support>Experimental for high resolution experiments</support>
     </domain>
 
-    <domain name="tx1v1">       
-      <nx>360</nx> <ny>240</ny>  
+    <domain name="tx1v1">
+      <nx>360</nx> <ny>240</ny>
       <file ocn_mask="tx1v1">domain.ocn.tx1v1.090122.nc </file>
       <desc>tripole v1 1-deg grid: testing proxy for high-res tripole ocean grids- do not use for scientific experiments</desc>
       <support>Experimental tripole ocean grid</support>
     </domain>
 
     <domain name="mpas120">
-      <nx>28574</nx>  <ny>1</ny>  
+      <nx>28574</nx>  <ny>1</ny>
       <file  mask="mpas120">domain.ocn.mpas120.121116.nc</file>
       <desc>mpas120 is a MPAS ocean grid that is roughly 1 degree resolution:</desc>
       <support>Experimental, under development</support>
     </domain>
 
     <domain name="rx1">
-      <nx>360</nx> <ny>180</ny>  
+      <nx>360</nx> <ny>180</ny>
       <desc>rx1 is 1 degree river routing grid (only valid for DROF):</desc>
       <support>Can only be used by DROF</support>
     </domain>
 
     <domain name="r05">
-      <nx>720</nx> <ny>360</ny>  
+      <nx>720</nx> <ny>360</ny>
       <desc>r05 is 1/2 degree river routing grid:</desc>
     </domain>
 
     <domain name="r01">
-      <nx>3600</nx> <ny>1800</ny> 
+      <nx>3600</nx> <ny>1800</ny>
       <desc>r01 is 1/10 degree river routing grid:</desc>
       <support>For experimental use by high resolution grids</support>
     </domain>
 
     <domain name="mp120v1">
-      <nx>28993</nx>  <ny>1</ny>    
+      <nx>28993</nx>  <ny>1</ny>
       <desc>mp120v1 is a MPAS ocean grid that is roughly 1 degree resolution:</desc>
       <support>Experimental, under development</support>
     </domain>
 
     <domain name="mp120r10v1">
-      <nx>139734</nx> <ny>1</ny>    
+      <nx>139734</nx> <ny>1</ny>
       <desc>mp120r10v1 is a MPAS grid:</desc>
       <support>Experimental, under development</support>
     </domain>
@@ -897,7 +897,7 @@
     <!-- WW3 domains-->
 
     <domain name="ww3a">
-      <nx>90</nx>  <ny>50</ny>  
+      <nx>90</nx>  <ny>50</ny>
       <file lnd_mask="ww3a">domain.lnd.ww3a_ww3a.120222.nc</file>
       <file ocn_mask="ww3a">domain.ocn.ww3a_ww3a.120222.nc</file>
       <path lnd_mask="ww3a">$DIN_LOC_ROOT/share/domains</path>
@@ -941,11 +941,11 @@
     </gridmap>
 
     <gridmap atm_grid="0.47x0.63" ocn_grid="tx0.1v2">
-      <ATM2OCN_FMAPNAME>cpl/cpl6/map_fv0.47x0.63_to_tx0.1v2_aave_da_090218.nc</ATM2OCN_FMAPNAME> 
-      <ATM2OCN_SMAPNAME>cpl/cpl6/map_fv0.47x0.63_to_tx0.1v2_bilin_da_090218.nc</ATM2OCN_SMAPNAME> 
-      <ATM2OCN_VMAPNAME>cpl/cpl6/map_fv0.47x0.63_to_tx0.1v2_bilin_da_090218.nc</ATM2OCN_VMAPNAME> 
-      <OCN2ATM_FMAPNAME>cpl/cpl6/map_tx0.1v2_to_fv0.47x0.63_aave_da_090218.nc</OCN2ATM_FMAPNAME> 
-      <OCN2ATM_SMAPNAME>cpl/cpl6/map_tx0.1v2_to_fv0.47x0.63_aave_da_090218.nc</OCN2ATM_SMAPNAME> 
+      <ATM2OCN_FMAPNAME>cpl/cpl6/map_fv0.47x0.63_to_tx0.1v2_aave_da_090218.nc</ATM2OCN_FMAPNAME>
+      <ATM2OCN_SMAPNAME>cpl/cpl6/map_fv0.47x0.63_to_tx0.1v2_bilin_da_090218.nc</ATM2OCN_SMAPNAME>
+      <ATM2OCN_VMAPNAME>cpl/cpl6/map_fv0.47x0.63_to_tx0.1v2_bilin_da_090218.nc</ATM2OCN_VMAPNAME>
+      <OCN2ATM_FMAPNAME>cpl/cpl6/map_tx0.1v2_to_fv0.47x0.63_aave_da_090218.nc</OCN2ATM_FMAPNAME>
+      <OCN2ATM_SMAPNAME>cpl/cpl6/map_tx0.1v2_to_fv0.47x0.63_aave_da_090218.nc</OCN2ATM_SMAPNAME>
     </gridmap>
 
     <gridmap atm_grid="0.9x1.25" ocn_grid="gx1v6">
@@ -1115,7 +1115,7 @@
       <OCN2ATM_SMAPNAME>cpl/cpl6/map_gx3v7_to_T31_aave_da_090903.nc</OCN2ATM_SMAPNAME>
     </gridmap>
 
-    <gridmap atm_grid="T85" ocn_grid="gx1v6"> 
+    <gridmap atm_grid="T85" ocn_grid="gx1v6">
       <ATM2OCN_FMAPNAME>cpl/gridmaps/T85/map_T85_to_gx1v6_aave_110411.nc</ATM2OCN_FMAPNAME>
       <ATM2OCN_SMAPNAME>cpl/gridmaps/T85/map_T85_to_gx1v6_bilin_110411.nc</ATM2OCN_SMAPNAME>
       <ATM2OCN_VMAPNAME>cpl/gridmaps/T85/map_T85_to_gx1v6_bilin_110411.nc</ATM2OCN_VMAPNAME>
@@ -1128,7 +1128,7 @@
       <LND2ATM_FMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_aave_110411.nc</LND2ATM_FMAPNAME>
       <LND2ATM_SMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_bilin_110411.nc</LND2ATM_SMAPNAME>
     </gridmap>
-    <gridmap atm_grid="T85" ocn_grid="tx0.1v2"> 
+    <gridmap atm_grid="T85" ocn_grid="tx0.1v2">
       <ATM2OCN_FMAPNAME>cpl/gridmaps/T85/map_T85_to_tx0.1v2_aave_110411.nc</ATM2OCN_FMAPNAME>
       <ATM2OCN_SMAPNAME>cpl/gridmaps/T85/map_T85_to_tx0.1v2_bilin_110411.nc</ATM2OCN_SMAPNAME>
       <ATM2OCN_VMAPNAME>cpl/gridmaps/T85/map_T85_to_tx0.1v2_bilin_110411.nc</ATM2OCN_VMAPNAME>
@@ -1142,14 +1142,14 @@
       <LND2ATM_SMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_aave_110411.nc</LND2ATM_SMAPNAME>
     </gridmap>
 
-    <gridmap atm_grid="512x1024" ocn_grid="tx0.1v2"> 
+    <gridmap atm_grid="512x1024" ocn_grid="tx0.1v2">
       <ATM2OCN_FMAPNAME>cpl/gridmaps/T341/map_T341_to_tx0.1v2_aave_110413.nc</ATM2OCN_FMAPNAME>
       <ATM2OCN_SMAPNAME>cpl/gridmaps/T341/map_T341_to_tx0.1v2_aave_110413.nc</ATM2OCN_SMAPNAME>
       <ATM2OCN_VMAPNAME>cpl/gridmaps/T341/map_T341_to_tx0.1v2_aave_110413.nc</ATM2OCN_VMAPNAME>
       <OCN2ATM_FMAPNAME>cpl/gridmaps/tx0.1v2/map_tx0.1v2_to_T341_aave_110413.nc</OCN2ATM_FMAPNAME>
       <OCN2ATM_SMAPNAME>cpl/gridmaps/tx0.1v2/map_tx0.1v2_to_T341_aave_110413.nc</OCN2ATM_SMAPNAME>
     </gridmap>
-    <gridmap atm_grid="512x1024" lnd_grid="0.23x0.31" > 
+    <gridmap atm_grid="512x1024" lnd_grid="0.23x0.31" >
       <ATM2LND_FMAPNAME>cpl/gridmaps/T341/map_T341_to_fv0.23x0.31_aave_110413.nc</ATM2LND_FMAPNAME>
       <ATM2LND_SMAPNAME>cpl/gridmaps/T341/map_T341_to_fv0.23x0.31_aave_110413.nc</ATM2LND_SMAPNAME>
       <LND2ATM_FMAPNAME>cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_T341_aave_110413.nc</LND2ATM_FMAPNAME>
@@ -1308,12 +1308,15 @@
       <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_gx3v7_e1000r500_090903.nc</ROF2OCN_RMAPNAME>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="gx1v6" >
-      <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_gx1v6_e1000r300_090226.nc</ROF2OCN_RMAPNAME>
+      <ROF2OCN_RMAPNAME >cpl/gridmaps/r05/map_r05_to_gx1v6_e1000r300_151109.nc</ROF2OCN_RMAPNAME>
+    </gridmap>
+    <gridmap rof_grid="r05" ocn_grid="gx1v7" >
+      <ROF2OCN_RMAPNAME >cpl/gridmaps/r05/map_r05_to_gx1v7_e1000r300_151109b.nc</ROF2OCN_RMAPNAME>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="tx1v1" >
       <ROF2OCN_RMAPNAME >cpl/cpl6/map_r05_to_tx1v1_e1000r500_080505.nc</ROF2OCN_RMAPNAME>
     </gridmap>
-    <gridmap rof_grid="r05" ocn_grid="tx0.1v2" > 
+    <gridmap rof_grid="r05" ocn_grid="tx0.1v2" >
       <ROF2OCN_RMAPNAME>cpl/cpl6/map_r05_to_tx0.1v2_r500e1000_080620.nc</ROF2OCN_RMAPNAME>
     </gridmap>
 

--- a/utils/perl5lib/Config/ConfigPes.pm
+++ b/utils/perl5lib/Config/ConfigPes.pm
@@ -18,7 +18,7 @@ BEGIN{
 #-----------------------------------------------------------------------------------------------
 sub setPes {
 
-    # Set the parameters for the pe layout.    
+    # Set the parameters for the pe layout.
 
     my($pesize_opts, $primary_component, $opts_ref, $config) = @_;
 
@@ -27,7 +27,7 @@ sub setPes {
 	# Reset the pes if a pes file is specified
 	my $pes_file = $$opts_ref{'pes_file'};
 	(-f "$pes_file")  or  $logger->logdie("** Cannot find pes_file \"$pes_file\" ***");
-	$config->reset_setup("$pes_file");    
+	$config->reset_setup("$pes_file");
 
     } else {
 
@@ -55,12 +55,12 @@ sub setPes {
 #-----------------------------------------------------------------------------------------------
 sub _setPESmatch1
 {
-    my ($pesize_opts, $ntasks, $nthrds, $rootpe, $config) = @_; 
+    my ($pesize_opts, $ntasks, $nthrds, $rootpe, $config) = @_;
 
     foreach my $comp ("ATM", "LND", "ICE", "OCN", "GLC", "WAV", "ROF", "CPL" ) {
-	$config->set("NTASKS_" . "${comp}", $ntasks); 
-	$config->set("NTHRDS_" . "${comp}", $nthrds); 
-	$config->set("ROOTPE_" . "${comp}", $rootpe); 
+	$config->set("NTASKS_" . "${comp}", $ntasks);
+	$config->set("NTHRDS_" . "${comp}", $nthrds);
+	$config->set("ROOTPE_" . "${comp}", $rootpe);
     }
 
     my $root;
@@ -79,14 +79,14 @@ sub _setPESmatch1
 #-------------------------------------------------------------------------------
 sub _setPESmatch2
 {
-    my ($pesize_opts, $ntasks, $nthrds, $rootpe, $config) = @_; 
+    my ($pesize_opts, $ntasks, $nthrds, $rootpe, $config) = @_;
 
     foreach my $comp ("ATM", "LND", "ICE", "OCN", "GLC", "WAV", "ROF", "CPL") {
-	$config->set("NTASKS_" . "$comp", $ntasks); 
-	$config->set("NTHRDS_" . "$comp", $nthrds); 
-	$config->set("ROOTPE_" . "$comp", $rootpe); 
+	$config->set("NTASKS_" . "$comp", $ntasks);
+	$config->set("NTHRDS_" . "$comp", $nthrds);
+	$config->set("ROOTPE_" . "$comp", $rootpe);
     }
-    
+
     my $root;
     if ($pesize_opts =~ m!^([0-9]+)x([0-9]+)D$!) {
 	$root = 0          ; $config->set('ROOTPE_ATM',$root);
@@ -98,13 +98,13 @@ sub _setPESmatch2
 	$root = 6 * $ntasks; $config->set('ROOTPE_ROF',$root);
 	$root = 7 * $ntasks; $config->set('ROOTPE_CPL',$root);
     }
-}    
+}
 
 #-------------------------------------------------------------------------------
 sub _setPESsettings
 {
     # Read xml file and obtain NTASKS, NTHRDS, ROOTPE and NINST for each component
-    my ($pesize_opts, $config) = @_; 
+    my ($pesize_opts, $config) = @_;
 
     my $mach		 = $config->get('MACH');
     my $grid_longname    = $config->get('GRID');
@@ -151,7 +151,7 @@ sub _setPESsettings
     # Set the match variables $mach_set and $grid_set
     # Determine possible matches in following order:
     # (1) model grid and model machine theh (2) model grid and 'any' machine
-    
+
     my $mach_set;
     my $grid_set;
 
@@ -164,14 +164,14 @@ sub _setPESsettings
     my $compset_match;
     my $pesize_match;
 
-    # Find default which will be overwritten by any match below 
+    # Find default which will be overwritten by any match below
     foreach my $node ($xml->findnodes(".//grid[(\@name =\"any\")]/mach[\@name =\"any\"]/pes[\@pesize =\"any\" and \@compset =\"any\"]")) {
 	next if($node->nodeType == XML_COMMENT_NODE);
 	$pe_select = $node;
     }
 
 
-    
+
         # Find nodes with grid= not 'any' and mach='any' - this override the default for $grid_match and $mach_match
     foreach my $node ($xml->findnodes(".//grid[not(\@name =\"any\")]/mach[\@name =\"any\"]")) {
 	next if($node->nodeType == XML_COMMENT_NODE);
@@ -221,7 +221,7 @@ sub _setPESsettings
 		$compset_match = $compset_attr;
 		$pesize_match  = $pesize_attr;
 		last;
-	    } 
+	    }
 	}
     }
     if ((! defined $compset_match) && (! defined $pesize_match)) {
@@ -235,7 +235,7 @@ sub _setPESsettings
 		last;
 	    }
 	}
-    } 
+    }
     if ((! defined $compset_match) && (! defined $pesize_match)) {
 	foreach my $node (@nodes) {
 	    my $compset_attr = $node->getAttribute('compset');
@@ -262,26 +262,37 @@ sub _setPESsettings
     }
     if (! defined $pe_select) {
 	$logger->logdie("ERROR: no pes match found in $pes_file ");
-    } 
+    }
     $logger->info("ConfigPES: grid          is $grid_longname ");
     $logger->info("ConfigPES: compset       is $compset_longname ");
     $logger->info("ConfigPES: grid match    is $grid_match ");
     $logger->info("ConfigPES: machine match is $mach_match");
-    $logger->info("ConfigPES: compset_match is $compset_match"); 
-    $logger->info("ConfigPES: pesize match  is $pesize_match "); 
-    
+    $logger->info("ConfigPES: compset_match is $compset_match");
+    $logger->info("ConfigPES: pesize match  is $pesize_match ");
+
+    my @additional_attributes = $pe_select->findnodes("./*");
+    foreach my $att (@additional_attributes){
+	my $name = $att->nodeName();
+	next if($name eq "comment");
+	next if($name eq "ntasks");
+	next if($name eq "rootpe");
+	next if($name eq "nthrds");
+	$logger->info("Setting $name = ".$att->textContent());
+	$config->set($name, $att->textContent());
+    }
+
     my $pes_per_node = $config->get('PES_PER_NODE');
-    my @pes_ntasks = $pe_select->findnodes("./ntasks"); 
-    my @pes_nthrds = $pe_select->findnodes("./nthrds"); 
-    my @pes_rootpe = $pe_select->findnodes("./rootpe"); 
+    my @pes_ntasks = $pe_select->findnodes("./ntasks");
+    my @pes_nthrds = $pe_select->findnodes("./nthrds");
+    my @pes_rootpe = $pe_select->findnodes("./rootpe");
     my %decomp;
-    
+
     foreach my $pes (@pes_ntasks, @pes_nthrds, @pes_rootpe) {
 	next if($pes->nodeType == XML_COMMENT_NODE);
 	my @children = $pes ->findnodes(".//*");
 	foreach my $child (@children) {
 	    next if($child->nodeType == XML_COMMENT_NODE);
-	    my $name  = uc $child->nodeName(); 
+	    my $name  = uc $child->nodeName();
 	    my $value =    $child->textContent();
             if ($value =~ /-?\d/){
             if ($value < 0) {
@@ -296,7 +307,7 @@ sub _setPESsettings
     }
 
 
-    
+
     foreach my $comp ("ATM", "LND", "ICE", "OCN", "GLC", "WAV", "ROF", "CPL") {
 	if($comp ne "ATM"){
 	    if(!defined $decomp{"NTASKS_$comp"}){
@@ -312,12 +323,12 @@ sub _setPESsettings
 		warn "No Match found for ROOTPE_$comp, using $decomp{ROOTPE_ATM}";
 	    }
 	}
-	    
+
 
 	my $ntasks = _clean($decomp{"NTASKS_$comp"});
 	my $nthrds = _clean($decomp{"NTHRDS_$comp"});
 	my $rootpe = _clean($decomp{"ROOTPE_$comp"});
-	
+
 	$config->set("NTASKS_$comp" , $ntasks);
 	$config->set("NTHRDS_$comp" , $nthrds);
 	$config->set("ROOTPE_$comp" , $rootpe);
@@ -331,8 +342,8 @@ sub _setPESsettings
 sub _clean
 {
     my ($name) = @_;
-  
-    $name =~ s/^\s+//; # strip any leading whitespace 
+
+    $name =~ s/^\s+//; # strip any leading whitespace
     $name =~ s/\s+$//; # strip any trailing whitespace
     return ($name);
 }


### PR DESCRIPTION
Main purpose of this is to bring changes from the cime4.4.5_cntlexp
branch to master. I'm pretty sure that I have gotten all changes that
weren't already on master, up through the latest branch tag
(cime4.4.5_cntlexp.06). Jim Edwards approved bringing all of these to
master. These mostly affect the definition of the B1850 compset, as well
as changing runoff mapping files. In addition, this adds the capability
to define additional xml variables in config_pes.xml.

In addition, this changes the "X" PE layout for B1850-f09 on yellowstone
(beyond the changes that were already on cime4.4.5_cntlexp). Jim Edwards
felt that this change should be made to master, but not to the
experimental branch. Specifically:
- Turn hyperthreading off. Cecile had been doing this manually; this
  change accomplishes this automatically.
- Shift the balance between ice and lnd/rof to get slightly better
  load balance (giving about a 2% performance boost). Ice is still
  taking significantly longer than lnd+rof, but ice is scaling so
  poorly at this PE count that I didn't think it was worth playing
  with this any more.

Test suite: yellowstone prealpha drv
   Ran this on the changes not including the last commit (i.e., not
   including the change to the "X" PE layout).
Test baseline: cesm1_5_alpha06c
Test namelist changes:
   Changes rof2ocn_rmapname
   Also, compared to that alpha tag, adds:
      tfreeze_option = 'minus1p8'
      But that's due to other changes made to master since that alpha
      tag
Test status: climate changing?
   Answer changes seen in X compsets were roundoff-level for some
   fields, greater than roundoff-level for r2xo_Forr_rofi,
   r2xo_Forr_rofl, x2oacc_Foxx_rofi, x2oacc_Foxx_rofl

   I believe these large answer changes come from the new runoff mapping
   files.

   In addition to the new mapping files, this also changes the
   definition (and PE layout) of the B1850 compset, which will change
   answers for that compset.

Also, from the final set of changes, ran a 3-day smoke test with the
create_newcase command that Cecile has been using:

   create_newcase -case b1850_new_0318a -compset B1850 -res f09_g16
      -mach yellowstone -user_mods_dir b1850 -pecount X

Fixes: None

User interface changes?: No

Code review: Jim Edwards
