### PR TITLE
Add new J compset

### DIFF
--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -274,6 +274,14 @@
     <lname>1850_CAM4_CLM40%CN_CICE_DOCN%SOM_RTM_SGLC_SWAV</lname>
   </compset>
 
+  <!-- All active except data atmosphere
+       Used for spinup and testing of CISM couplings -->
+
+  <compset>
+     <alias>J1850G2</alias>
+     <lname>1850_DATM%CRU_CLM50%BGC_CICE_POP2_MOSART_CISM2_SWAV</lname>
+  </compset>
+
   <entries>
 
  <entry id="RUN_TYPE">

--- a/cime_config/cesm/allactive/config_pes.xml
+++ b/cime_config/cesm/allactive/config_pes.xml
@@ -1681,7 +1681,8 @@
      <!-- Ideally, we wouldn't match against yellowstone here. However, if we
           set mach name="any", it seems that the ConfigPES logic just tries
           looking in other blocks (which have a specific grid and specific
-          machine), and doesn't check this block -->
+          machine), and doesn't check this block. (See
+          https://github.com/CESM-Development/cime/issues/403) -->
      <mach name="yellowstone">
         <pes pesize="any" compset="DATM.+CLM.+CICE.+POP">
            <comment>Load balanced for 1850_DATM%CRU_CLM50%BGC_CICE_POP2_MOSART_CISM2_SWAV on yellowstone</comment>

--- a/cime_config/cesm/allactive/config_pes.xml
+++ b/cime_config/cesm/allactive/config_pes.xml
@@ -1446,7 +1446,7 @@
   </grid>
   <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
     <mach name="yellowstone">
-      <pes pesize="any" compset="BGC">
+      <pes pesize="any" compset="CAM.+CLM.+CICE.+POP.+BGC">
 	<comment>none</comment>
 	<ntasks>
 	  <ntasks_atm>300</ntasks_atm>

--- a/cime_config/cesm/allactive/config_pes.xml
+++ b/cime_config/cesm/allactive/config_pes.xml
@@ -1674,9 +1674,16 @@
        |..CPL..|
        |......GLC......|
   -->
-  <grid name="l%0.9x1.25.+oi%gx1">
-     <mach name="any">
-        <pes pesize="any" compset="DATM.+CLM.+CICE.+POP.+CISM2">
+  <!-- Ideally, we wouldn't specify the atmosphere resolution here, because it
+       is irrelevant. However, ConfigPES doesn't seem to match the grid properly
+       unless the atmosphere resolution is specified. -->
+  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1">
+     <!-- Ideally, we wouldn't match against yellowstone here. However, if we
+          set mach name="any", it seems that the ConfigPES logic just tries
+          looking in other blocks (which have a specific grid and specific
+          machine), and doesn't check this block -->
+     <mach name="yellowstone">
+        <pes pesize="any" compset="DATM.+CLM.+CICE.+POP">
            <comment>Load balanced for 1850_DATM%CRU_CLM50%BGC_CICE_POP2_MOSART_CISM2_SWAV on yellowstone</comment>
            <ntasks>
               <ntasks_atm>-2</ntasks_atm>

--- a/cime_config/cesm/allactive/config_pes.xml
+++ b/cime_config/cesm/allactive/config_pes.xml
@@ -1667,4 +1667,50 @@
     </mach>
   </grid>
 
+  <!-- J compset (all active except data atmosphere)
+       Laid out as follows:
+       |LND|ICE|ATM|OCN|
+       |ROF|
+       |..CPL..|
+       |......GLC......|
+  -->
+  <grid name="l%0.9x1.25.+oi%gx1">
+     <mach name="any">
+        <pes pesize="any" compset="DATM.+CLM.+CICE.+POP.+CISM2">
+           <comment>Load balanced for 1850_DATM%CRU_CLM50%BGC_CICE_POP2_MOSART_CISM2_SWAV on yellowstone</comment>
+           <ntasks>
+              <ntasks_atm>-2</ntasks_atm>
+              <ntasks_lnd>-18</ntasks_lnd>
+              <ntasks_rof>-18</ntasks_rof>
+              <ntasks_ice>-12</ntasks_ice>
+              <ntasks_ocn>-32</ntasks_ocn>
+              <ntasks_glc>-64</ntasks_glc>
+              <ntasks_wav>1</ntasks_wav>
+              <ntasks_cpl>-30</ntasks_cpl>
+           </ntasks>
+           <nthrds>
+	      <nthrds_atm>1</nthrds_atm>
+	      <nthrds_lnd>1</nthrds_lnd>
+	      <nthrds_rof>1</nthrds_rof>
+	      <nthrds_ice>1</nthrds_ice>
+	      <nthrds_ocn>1</nthrds_ocn>
+	      <nthrds_glc>1</nthrds_glc>
+	      <nthrds_wav>1</nthrds_wav>
+	      <nthrds_cpl>1</nthrds_cpl>
+           </nthrds>
+           <rootpe>
+              <rootpe_atm>-30</rootpe_atm>
+              <rootpe_lnd>0</rootpe_lnd>
+              <rootpe_rof>0</rootpe_rof>
+              <rootpe_ice>-18</rootpe_ice>
+              <rootpe_ocn>-32</rootpe_ocn>
+              <rootpe_glc>0</rootpe_glc>
+              <rootpe_wav>0</rootpe_wav>
+              <rootpe_cpl>0</rootpe_cpl>
+           </rootpe>
+        </pes>
+     </mach>
+  </grid>
+
+
 </config_pes>

--- a/cime_config/cesm/allactive/config_pes.xml
+++ b/cime_config/cesm/allactive/config_pes.xml
@@ -1686,14 +1686,14 @@
         <pes pesize="any" compset="DATM.+CLM.+CICE.+POP">
            <comment>Load balanced for 1850_DATM%CRU_CLM50%BGC_CICE_POP2_MOSART_CISM2_SWAV on yellowstone</comment>
            <ntasks>
-              <ntasks_atm>-2</ntasks_atm>
-              <ntasks_lnd>-18</ntasks_lnd>
-              <ntasks_rof>-18</ntasks_rof>
-              <ntasks_ice>-12</ntasks_ice>
-              <ntasks_ocn>-32</ntasks_ocn>
-              <ntasks_glc>-64</ntasks_glc>
+              <ntasks_atm>-1</ntasks_atm>
+              <ntasks_lnd>-21</ntasks_lnd>
+              <ntasks_rof>-21</ntasks_rof>
+              <ntasks_ice>-10</ntasks_ice>
+              <ntasks_ocn>-16</ntasks_ocn>
+              <ntasks_glc>-48</ntasks_glc>
               <ntasks_wav>1</ntasks_wav>
-              <ntasks_cpl>-30</ntasks_cpl>
+              <ntasks_cpl>-31</ntasks_cpl>
            </ntasks>
            <nthrds>
 	      <nthrds_atm>1</nthrds_atm>
@@ -1706,10 +1706,10 @@
 	      <nthrds_cpl>1</nthrds_cpl>
            </nthrds>
            <rootpe>
-              <rootpe_atm>-30</rootpe_atm>
+              <rootpe_atm>-31</rootpe_atm>
               <rootpe_lnd>0</rootpe_lnd>
               <rootpe_rof>0</rootpe_rof>
-              <rootpe_ice>-18</rootpe_ice>
+              <rootpe_ice>-21</rootpe_ice>
               <rootpe_ocn>-32</rootpe_ocn>
               <rootpe_glc>0</rootpe_glc>
               <rootpe_wav>0</rootpe_wav>

--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -16,15 +16,15 @@
       <test name="CME_Ld5">
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
       </test>
+      <test name="ERR">
+        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">edison</machine>
+      </test>
       <test name="ERS_E_Ld7">
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
       </test>
       <test name="ERS_Ld7">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
         <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-      <test name="ERR">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">edison</machine>
       </test>
       <test name="PET_PT">
         <machine compiler="gnu" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
@@ -272,6 +272,13 @@
     <grid name="f19_g16">
       <test name="ERS_Ld5">
         <machine compiler="intel" testtype="prebeta" testmods="cice/default">yellowstone</machine>
+      </test>
+    </grid>
+  </compset>
+  <compset name="J1850G2">
+    <grid name="f09_g16_gl4">
+      <test name="SMS_Ld5">
+        <machine compiler="gnu" testtype="prebeta" testmods="allactive/cism/test_coupling">yellowstone</machine>
       </test>
     </grid>
   </compset>

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -3051,7 +3051,10 @@
       If true, albedos are computed with the assumption that downward
       solar radiation from the atm component is a daily average quantity and
       does not have a zenith-angle dependence. This is often the case when
-      using a data atm component. Only used for compsets with DATM and POP (currently C, G and J)
+      using a data atm component. Only used for compsets with DATM and POP (currently C, G and J).
+      NOTE: This should really depend on the datm forcing and not the compset per se.
+      So, for example, whether it is set in a J compset should depend on
+      what datm forcing is used.
     </desc>
   </entry>
 

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -3043,7 +3043,7 @@
     <group>run_component_cpl</group>
     <file>env_run.xml</file>
     <desc>
-      Only used for compsets with DATM and POP (currently C and G):
+      Only used for compsets with DATM and POP (currently C, G and J):
       If true, compute albedos to work with daily avg SW down
       If false (default), albedos are computed with the assumption that downward
       solar radiation from the atm component has a diurnal cycle and zenith-angle
@@ -3051,7 +3051,7 @@
       If true, albedos are computed with the assumption that downward
       solar radiation from the atm component is a daily average quantity and
       does not have a zenith-angle dependence. This is often the case when
-      using a data atm component. Only used for compsets with DATM and POP (currently C and G)
+      using a data atm component. Only used for compsets with DATM and POP (currently C, G and J)
     </desc>
   </entry>
 
@@ -3065,12 +3065,12 @@
     <group>run_component_cpl</group>
     <file>env_run.xml</file>
     <desc>
-      Only used for compsets with DATM and POP (currently C and G):
+      Only used for compsets with DATM and POP (currently C, G and J):
       If ocn, ocn provides EP balance factor for precipitation.
       Provides EP balance factor for precip for POP. A factor computed by
       POP is applied to precipitation so that precipitation balances
       evaporation and ocn global salinity does not drift. This is intended
-      for use when coupling POP to a DATM. Only used for C and G compsets.
+      for use when coupling POP to a DATM. Only used for C, G and J compsets.
       Default is off
     </desc>
   </entry>

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -3008,7 +3008,7 @@
     <type>char</type>
     <default_value>8</default_value>
     <values>
-      <value compset="_DATM.*_POP2">$ATM_NCPL</value>
+      <value compset="_DATM.*_POP2.*_DROF">$ATM_NCPL</value>
       <value compset="_DATM.*_DOCN%SOM">$ATM_NCPL</value>
       <value compset="_DATM.*_DLND.*_DICE.*_DOCN">$ATM_NCPL</value>
       <value compset="_XATM.*_XLND.*_XICE.*_XOCN">$ATM_NCPL</value>

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -3032,6 +3032,8 @@
   </entry>
 
 
+  <!-- Logic for CPL_ALBAV should be reworked to depend on datm forcing rather
+       than compset: see https://github.com/ESMCI/cime/issues/120 -->
   <entry id="CPL_ALBAV">
     <type>logical</type>
     <valid_values>true,false</valid_values>

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -2920,7 +2920,7 @@
       <value compset="_DATM%COPYALL_NPS"    >72</value>
       <value compset="_DATM.*_CLM"          >48</value>
       <value compset="_DATM.*_DICE.*_POP2"  >4</value>
-      <value compset="_DATM.*_CICE.*_POP2"  >24</value>
+      <value compset="_DATM.*_SLND.*_CICE.*_POP2">24</value>
       <value compset="_DATM.*_CICE.*_DOCN"  >24</value>
       <value compset="_DATM.*_DOCN%US20"    >24</value>
       <value compset="_MPAS"                >1</value>


### PR DESCRIPTION
This set of changes adds a new "J" compset, which is all active except
for a data atmosphere. This compset is being used by the Land Ice
Working Group for spinup and testing of couplings between glc and other
components. I am defining this in "allactive", analogously to the
definition of E compsets in "allactive": this is a "mostly active"
compset that doesn't have a clear home elsewhere.

This also fixes some xml matches that were too general, and so were
causing problems for default settings in this new compset

Test suite: full yellowstone prealpha test suite
Test baseline: cesm1_5_alpha06c
Test namelist changes: none
Test status: bit for bit

   All tests passed except those listed as failing in the test db.

   These tests were run with a version of this cime branch that was
   rebased onto cime4.4.7 (the cime version in alpha06c).

   Also ran the new test in the prebeta test list:
   SMS_Ld5.f09_g16_gl4.J1850G2.yellowstone_gnu.allactive-cism-test_coupling

Fixes: none

User interface changes?: none

Code review: none yet
