### PR TITLE
add usage message for -keepexe flag in create_clone

### DIFF
--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -24,7 +24,7 @@ my $banner = '=' x 80;
 #-----------------------------------------------------------------------------------------------
 # Setting autoflush (an IO::Handle method) on STDOUT helps in debugging.  It forces the test
 # descriptions to be printed to STDOUT before the error messages start.
-*STDOUT->autoflush();                  
+*STDOUT->autoflush();
 
 if ($#ARGV == -1) {
     print "Invoke create_clone -help [or -h] for usage\n";
@@ -45,6 +45,7 @@ OPTIONS
      -help [or -h]        Print usage to STDOUT.
      -case <caseroot>     Specify the new case directory.
      -clone <cloneroot>   Specify the case to be cloned.
+     -keepexe              Sets EXEROOT to point to original build
      -mach_dir            Optional location of machines directory
      -project <name>      Specify a project id for the case (optional)
                           default: user-specified environment variable PROJECT or ACCOUNT
@@ -99,7 +100,7 @@ $caseroot = abs_path("$case");
 if (-d $caseroot) {
     die "New caseroot directory $caseroot already exists \n";
 }
-my @dirs = split "/", $caseroot, -1; 
+my @dirs = split "/", $caseroot, -1;
 my $num = scalar @dirs;
 $case = @dirs[$num-1];
 
@@ -113,7 +114,7 @@ $cloneroot = abs_path("$clone");
 (-d "$cloneroot")  or  die <<"EOF";
 ** Cannot find cloneroot directory \"$cloneroot\" **
 EOF
-my @dirs = split "/", $cloneroot, -1; 
+my @dirs = split "/", $cloneroot, -1;
 my $num = scalar @dirs;
 $clone = @dirs[$num-1];
 
@@ -152,18 +153,18 @@ require Config::SetupTools;
 require Batch::BatchMaker;
 
 #-----------------------------------------------------------------------------------------------
-# Create the case directory tree utilizing the clone tree 
+# Create the case directory tree utilizing the clone tree
 my $sysmod;
 
-# Create $caseroot directories 
-$sysmod = "mkdir -p $caseroot"; 
+# Create $caseroot directories
+$sysmod = "mkdir -p $caseroot";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
-$sysmod = "cp -rp $cloneroot/* $caseroot"; 
+$sysmod = "cp -rp $cloneroot/* $caseroot";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 
 # Remove unwanted files from $cloneroot
 # Note - script files used to be named using the first 12-15 chars of $clone, but are now named case.$SCRIPT
-# Need to remove those. 
+# Need to remove those.
 $sysmod = "rm -rf $caseroot/Buildconf/*"  ; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -rf $caseroot/CaseDocs/*"   ; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -rf $caseroot/LockedFiles/*"; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
@@ -171,13 +172,13 @@ $sysmod = "rm -rf $caseroot/logs/*"       ; system ($sysmod); if ($? == -1) {die
 $sysmod = "rm -rf $caseroot/timing/*"     ; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -rf $caseroot/TestStatus*"  ; system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 # Remove case.* scripts
-$sysmod = "rm -f $caseroot/case.*"; 
+$sysmod = "rm -f $caseroot/case.*";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 $sysmod = "rm -f $caseroot/*~";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 
 # Need to copy back in the CaseDocs/README
-$sysmod = "cp -rp $cloneroot/README.case $caseroot/CaseDocs/README.case"; 
+$sysmod = "cp -rp $cloneroot/README.case $caseroot/CaseDocs/README.case";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 
 # append create_clone and args to cloned case README.case
@@ -203,7 +204,7 @@ my @casesearch = ($caseroot);
 find(\&substitute, @casesearch);
 
 # Obtain variables needed below
-my $username  = "$ENV{'USER'}"; 
+my $username  = "$ENV{'USER'}";
 $sysmod = "./xmlchange USER=$username"			; system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 $sysmod = "./xmlchange CASE=$case"			; system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 $sysmod = "./xmlchange CASEROOT=$caseroot"		; system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
@@ -223,7 +224,7 @@ if($opts{'keepexe'})
     $sysmod = "cp -Rp $cloneroot/Buildconf/* $caseroot/Buildconf/"; system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 }
 
-# --- Set project id 
+# --- Set project id
 # Note: we do not just copy this from the clone because it seems likely that
 # users will want to change this sometimes, especially when cloning another
 # user's case. However, note that, if a project is not given, the fallback will
@@ -239,7 +240,7 @@ if ($opts{'project'}) {
 my $set_project = ProjectTools::set_project($project);
 if ($set_project) {
     $sysmod = "./xmlchange -file env_batch.xml -id PROJECT -val $project"; system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
-} 
+}
 
 # Copy env_case.xml in locked files
 $sysmod = "cp $caseroot/env_case.xml $caseroot/LockedFiles/env_case.xml";
@@ -259,17 +260,17 @@ $sysmod = "chmod 755 $caseroot/case.build";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 
 # Create case.clean_build
-$sysmod = "cp $cimeroot/scripts/Tools/clean_build $caseroot/case.clean_build"; 
+$sysmod = "cp $cimeroot/scripts/Tools/clean_build $caseroot/case.clean_build";
 system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
-    
+
 # Create case.submit
-$sysmod = "cp  $cimeroot/scripts/Tools/case.submit $caseroot/case.submit"; 
+$sysmod = "cp  $cimeroot/scripts/Tools/case.submit $caseroot/case.submit";
 system($sysmod) == 0 or die "ERROR: $sysmod failed: $?\n";
 
 
 #-----------------------------------------------------------------------------------------------
 # Create batch script
-$sysmod = "./case.setup"; 
+$sysmod = "./case.setup";
 system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
 
 


### PR DESCRIPTION
Mostly I did this to test the PR template.   It works!

Test suite: None
Test baseline: None
Test namelist changes: None
Test status: bit for bit

Fixes: None

User interface changes?: Added help message for create_clone -keepexe option

Code review: 
