### PR TITLE
Change RTM tests to MOSART,fix long line,

### DIFF
--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -106,6 +106,11 @@
   </compset>
 
   <compset>
+    <alias>BC5L45BGC</alias>
+    <lname>2000_CAM5_CLM45%BGC_CICE_POP2_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>BC4FCHML40CNR</alias>
     <lname>2000_CAM4%FCHM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname>
   </compset>
@@ -135,6 +140,11 @@
     <lname>1850_CAM5_CLM45%BGC_CICE_POP2_RTM_SGLC_SWAV</lname>
   </compset>
 
+  <compset>
+    <alias>B1850C5L45BGC</alias>
+    <lname>1850_CAM5_CLM45%BGC_CICE_POP2_MOZART_SGLC_SWAV</lname>
+  </compset>
+
 
   <compset>
     <alias>B1850C4RCO2L40CNR</alias>
@@ -145,6 +155,11 @@
   <compset>
     <alias>B1850C5WCCML45CNR</alias>
     <lname>1850_CAM5%WCCM_CLM45%CN_CICE_POP2_RTM_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>B1850C5WCCML45CN</alias>
+    <lname>1850_CAM5%WCCM_CLM45%CN_CICE_POP2_MOSART_SGLC_SWAV</lname>
   </compset>
 
 
@@ -184,6 +199,11 @@
   </compset>
 
   <compset>
+    <alias>BHISTC5L45BGC</alias>
+    <lname>HIST_CAM5_CLM45%BGC_CICE_POP2_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>BHISTC4FCHML40CNR</alias>
     <lname>HIST_CAM4%FCHM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname>
   </compset>
@@ -208,10 +228,20 @@
     <lname>RCP8_CAM5_CLM45%BGC_CICE_POP2_RTM_SGLC_SWAV</lname>
   </compset>
 
+  <compset>
+    <alias>BRCP85C5L45BGC</alias>
+    <lname>RCP8_CAM5_CLM45%BGC_CICE_POP2_MOSART_SGLC_SWAV</lname>
+  </compset>
+
   <!-- Climate Simulation Lab compsets for Keith Lindsay -->
   <compset>
     <alias>B1850C4L45BGCRBPRP</alias>
     <lname>1850_CAM4_CLM45%BGC_CICE_POP2%ECO_RTM_SGLC_SWAV_BGC%BPRP</lname>
+  </compset>
+
+  <compset>
+    <alias>B1850C4L45BGCBPRP</alias>
+    <lname>1850_CAM4_CLM45%BGC_CICE_POP2%ECO_MOSART_SGLC_SWAV_BGC%BPRP</lname>
   </compset>
 
   <compset>
@@ -233,8 +263,18 @@
   </compset>
 
   <compset>
+    <alias>BC5L45BGCG</alias>
+    <lname>2000_CAM5_CLM45%BGC_CICE_POP2_MOSART_CISM1_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>B1850C5L45BGCRG2</alias>
     <lname>1850_CAM5_CLM45%BGC_CICE_POP2_RTM_CISM2_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>B1850C5L45BGCG2</alias>
+    <lname>1850_CAM5_CLM45%BGC_CICE_POP2_MOSART_CISM2_SWAV</lname>
   </compset>
 
 
@@ -265,7 +305,7 @@
 
   <compset>
     <alias>E1850C5L45TEST</alias>
-    <lname>1850_CAM5_CLM45%SP_CICE_DOCN%SOM_RTM_SGLC_SWAV_TEST</lname>
+    <lname>1850_CAM5_CLM45%SP_CICE_DOCN%SOM_MOSART_SGLC_SWAV_TEST</lname>
   </compset>
 
   <compset>

--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -2,6 +2,9 @@
 <testlist>
   <compset name="B1850">
     <grid name="f09_g16">
+      <test name="SMS_D">
+        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
+      </test>
       <test name="ERI">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>

--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -11,6 +11,16 @@
         <machine compiler="intel" testtype="prealpha" testmods="allactive/default">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/default">yellowstone</machine>
       </test>
+      <test name="NOC">
+        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
+        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
+      </test>
+    </grid>
+    <grid name="f45_g37">
+      <test name="PEA_P1">
+        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">hobart</machine>
+        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">hobart</machine>
+      </test>
     </grid>
     <grid name="f19_g16">
       <test name="CME_Ld5">
@@ -28,6 +38,10 @@
       </test>
       <test name="PET_PT">
         <machine compiler="gnu" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
+      </test>
+      <test name="ERR_N3">
+        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
+        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
       </test>
     </grid>
     <grid name="ne120_g16">
@@ -103,27 +117,7 @@
       </test>
     </grid>
   </compset>
-  <compset name="B1850R">
-    <grid name="f09_g16">
-      <test name="NOC">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-    <grid name="f19_g16">
-      <test name="ERR_N3">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-    <grid name="f45_g37">
-      <test name="PEA_P1">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">hobart</machine>
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">hobart</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850RG">
+  <compset name="B1850G">
     <grid name="f09_g16">
       <test name="ERS">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01io">yellowstone</machine>
@@ -136,18 +130,16 @@
       </test>
     </grid>
   </compset>
-  <compset name="B1850RW">
-    <grid name="f19_g16">
-      <test name="ERS">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
   <compset name="B1850W">
     <grid name="f09_g16">
       <test name="ERS">
         <machine compiler="pgi" testtype="prealpha" testmods="allactive/defaultio">bluewaters</machine>
         <machine compiler="cray" testtype="prealpha" testmods="allactive/defaultio">edison</machine>
+        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
+      </test>
+    </grid>
+    <grid name="f19_g16">
+      <test name="ERS">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
       </test>
     </grid>

--- a/cime_config/cesm/allactive/usermods_dirs/b1850/user_nl_clm
+++ b/cime_config/cesm/allactive/usermods_dirs/b1850/user_nl_clm
@@ -1,5 +1,4 @@
 fsurdat = '/glade/p/cesmdata/cseg/inputdata/lnd/clm2/surfdata_map/surfdata_0.9x1.25_16pftsmodwshrubwglcr_simyr1850_c151210.nc'
-use_init_interp = .true.
 init_interp_fill_missing_with_natveg = .true.
 finidat = '/glade/scratch/hannay/land_ic/b.e15.B1850.f09_g16.pi_control.35_ic.clm2.r.0001-01-06-00000.nc'
 

--- a/share/csm_share/shr/shr_frz_mod.F90.in
+++ b/share/csm_share/shr/shr_frz_mod.F90.in
@@ -100,7 +100,8 @@
       shr_frz_freezetemp = max(s,0.0_R8) &
          / (-18.48_R8 + (0.01848_R8*max(s,0.0_R8)))
    else
-      call shr_sys_abort(subname//' ERROR: not intialized correctly with a valid tfreeze_option - call shr_frz_freezetemp_init first with a valid tfreeze_option')
+      call shr_sys_abort(subname//' ERROR: not intialized correctly with a valid tfreeze_option - &
+                                  call shr_frz_freezetemp_init first with a valid tfreeze_option')
    endif
 
    shr_frz_freezetemp = max(shr_frz_freezetemp,-2.0_R8)


### PR DESCRIPTION
Change RTM tests to MOSART when CLM4.5 or newer is used.  Fix line
that was too long n shr_frz_mod.F90.in.  Removed use_init_interp for the
b1850 usermods for clm.

Test suite:  ERS.f09_g16.B1850RG.yellowstone_intel
Test baseline: N/A
Test namelist changes: RTM tests changed to MOSART for CLM4.5 or newer
Test status: bit for bit

Fixes: none

User interface changes?: No

Code review:
