### PR TITLE
Fixes

### DIFF
--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -2,9 +2,6 @@
 <testlist>
   <compset name="B1850">
     <grid name="f09_g16">
-      <test name="SMS_D">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
-      </test>
       <test name="ERI">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
@@ -26,6 +23,9 @@
       </test>
     </grid>
     <grid name="f19_g16">
+      <test name="SMS_D">
+        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
+      </test>
       <test name="CME_Ld5">
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
       </test>

--- a/driver_cpl/bld/namelist_files/namelist_defaults_drv.xml
+++ b/driver_cpl/bld/namelist_files/namelist_defaults_drv.xml
@@ -107,7 +107,7 @@
 <cpl_decomp>$CPL_DECOMP</cpl_decomp>
 <wall_time_limit>-1.0</wall_time_limit> 
 <force_stop_at>month</force_stop_at> 
-<flux_diurnal>.false.</flux_diurnal> 
+<flux_diurnal>.true.</flux_diurnal> 
 
 <run_barriers COMP_RUN_BARRIERS="TRUE">.true.</run_barriers> 
 <run_barriers COMP_RUN_BARRIERS="FALSE">.false.</run_barriers> 

--- a/driver_cpl/bld/namelist_files/namelist_definition_drv.xml
+++ b/driver_cpl/bld/namelist_files/namelist_definition_drv.xml
@@ -462,7 +462,7 @@ type="logical"
 category="control" 
 group="seq_infodata_inparm">
 If true, turn on diurnal cycle in computing atm/ocn fluxes
-default: false
+default: true
 </entry>
 
 <entry 


### PR DESCRIPTION
Set the default for flux_diurnal to true.
Changed debug smoke test for B1850 from f09 to f19

Test suite:  SMS_D.f19_g16.B1850.yellowstone_intel
Test baseline: 
Test namelist changes: SMS_D.f19_g16.B1850
Test status: bit for bit

Fixes: 

User interface changes?: 

Code review: 
