### PR TITLE
Fixes

### DIFF
--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -45,28 +45,23 @@
   </compset>
 
   <compset>
-    <alias>B1850G</alias>
-    <lname>1850_CAM55_CLM50%BGC-CROP_CICE_POP2_MOSART_CISM1%NOEVOLVE_SWAV</lname>
-  </compset>
-
-  <compset>
     <alias>B1850RG</alias>
-    <lname>1850_CAM55_CLM50%BGC-CROP_CICE_POP2_RTM_CISM1%NOEVOLVE_SWAV</lname>
+    <lname>1850_CAM55_CLM50%BGC_CICE_POP2%ECO_RTM_CISM1%NOEVOLVE_SWAV_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>B1850RW</alias>
-    <lname>1850_CAM55_CLM50%BGC-CROP_CICE_POP2_RTM_SGLC_DWAV</lname>
+    <lname>1850_CAM55_CLM50%BGC_CICE_POP2%ECO_RTM_SGLC_DWAV_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>B1850GW</alias>
-    <lname>1850_CAM55_CLM50%BGC-CROP_CICE_POP2_MOSART_CISM1%NOEVOLVE_DWAV</lname>
+    <lname>1850_CAM55_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_DWAV_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>B1850W</alias>
-    <lname>1850_CAM55_CLM50%BGC-CROP_CICE_POP2_MOSART_SGLC_DWAV</lname>
+    <lname>1850_CAM55_CLM50%BGC_CICE_POP2%ECO_MOSART_SGLC_DWAV_BGC%BDRD</lname>
   </compset>
 
   <compset>
@@ -76,12 +71,12 @@
 
   <compset>
     <alias>B1850R</alias>
-    <lname>1850_CAM55_CLM50%BGC-CROP_CICE_POP2_RTM_SGLC_SWAV</lname>
+    <lname>1850_CAM55_CLM50%BGC_CICE_POP2%ECO_RTM_SGLC_SWAV_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>B1850Cw</alias>  
-    <lname>1850_CAM55%WTSM_CLM50%BGC-CROP_CICE_POP2_MOSART_SGLC_SWAV</lname>
+    <lname>1850_CAM55%WTSM_CLM50%BGC_CICE_POP2%ECO_MOSART_SGLC_SWAV_BGC%BDRD</lname>
   </compset>
 
 
@@ -282,7 +277,7 @@
 
   <compset>
     <alias>ETEST</alias>
-    <lname>2000_CAM55_CLM50%CROP_CICE_DOCN%SOM_MOSART_SGLC_SWAV_TEST</lname>
+    <lname>2000_CAM55_CLM50_CICE_DOCN%SOM_MOSART_SGLC_SWAV_TEST</lname>
   </compset>
 
   <compset>

--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -4,16 +4,23 @@
     <grid name="f09_g16">
       <test name="ERI">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
+        <machine compiler="intel" testtype="prebeta" testmods="allactive/cesm2dev01">edison</machine>
       </test>
       <test name="PFS">
         <machine compiler="pgi " testtype="prebeta" testmods="allactive/default">bluewaters</machine>
         <machine compiler="intel" testtype="prealpha" testmods="allactive/default">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/default">yellowstone</machine>
+        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01">yellowstone</machine>
       </test>
       <test name="NOC">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
+      </test>
+      <test name="ERS">
+        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01io">yellowstone</machine>
+      </test>
+      <test name="SMS_Ld7">
+        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01io">yellowstone</machine>
       </test>
     </grid>
     <grid name="f45_g37">
@@ -117,19 +124,6 @@
     <grid name="f19_g16">
       <test name="ERS_Ld7">
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850G">
-    <grid name="f09_g16">
-      <test name="ERS">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01io">yellowstone</machine>
-      </test>
-      <test name="PFS">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01">yellowstone</machine>
-      </test>
-      <test name="SMS_Ld7">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01io">yellowstone</machine>
       </test>
     </grid>
   </compset>


### PR DESCRIPTION
B1850s compsets were made more consistent to the B1850 compset by removing CROP from CLM50 
and adding %ECO to POP2, and adding BGC%BDRD.

Test suite: 
Test baseline: 
Test namelist changes:  B1850G tests moved into B1850
Test status: B1850s compsets not bfb

Fixes:

User interface changes?: 

Code review: 
