### PR TITLE
need an additional fix for user compsets that do not match any defined alias

### DIFF
--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -464,9 +464,10 @@ ConfigCompsetGrid::setComponent($file, $config);
 # This determines driver_cpl/cime_config/config_component.xml settings that are compset specific
 # and also check that compset is supported for target grid
 # Note- this needs to come last since it will overwrite any values set above
-
-ConfigCompsetGrid::setCompsetGeneralVars($config);
-
+# if support_level is not defined this is a user_compset with no alias match
+if (defined $support_level){
+    ConfigCompsetGrid::setCompsetGeneralVars($config);
+}
 # Special case - if land and river grids are different AND there is no mapping file
 # between land and river then set the river mode  to null if the river component is rtm
 my $rof_comp = $config->get('COMP_ROF');


### PR DESCRIPTION
Fixes a problem when a user compset is specified that does not match any compset alias.
Tested with -user_compset AMIP_CAM5_CLM50%BGC_CICE%PRES_DOCN%DOM_MOSART_CISM1%NOEVOLVE_SWAV   -res f09_f09 

Test suite: drv yellowstone prealpha 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes: 

User interface changes?:  None

Code review: 
