### PR TITLE
fix shr_flux_atmocn_diurnal restart problem related to cold start initialization logic

### DIFF
--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -45,28 +45,23 @@
   </compset>
 
   <compset>
-    <alias>B1850G</alias>
-    <lname>1850_CAM55_CLM50%BGC-CROP_CICE_POP2_MOSART_CISM1%NOEVOLVE_SWAV</lname>
-  </compset>
-
-  <compset>
     <alias>B1850RG</alias>
-    <lname>1850_CAM55_CLM50%BGC-CROP_CICE_POP2_RTM_CISM1%NOEVOLVE_SWAV</lname>
+    <lname>1850_CAM55_CLM50%BGC_CICE_POP2%ECO_RTM_CISM1%NOEVOLVE_SWAV_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>B1850RW</alias>
-    <lname>1850_CAM55_CLM50%BGC-CROP_CICE_POP2_RTM_SGLC_DWAV</lname>
+    <lname>1850_CAM55_CLM50%BGC_CICE_POP2%ECO_RTM_SGLC_DWAV_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>B1850GW</alias>
-    <lname>1850_CAM55_CLM50%BGC-CROP_CICE_POP2_MOSART_CISM1%NOEVOLVE_DWAV</lname>
+    <lname>1850_CAM55_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_DWAV_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>B1850W</alias>
-    <lname>1850_CAM55_CLM50%BGC-CROP_CICE_POP2_MOSART_SGLC_DWAV</lname>
+    <lname>1850_CAM55_CLM50%BGC_CICE_POP2%ECO_MOSART_SGLC_DWAV_BGC%BDRD</lname>
   </compset>
 
   <compset>
@@ -76,12 +71,12 @@
 
   <compset>
     <alias>B1850R</alias>
-    <lname>1850_CAM55_CLM50%BGC-CROP_CICE_POP2_RTM_SGLC_SWAV</lname>
+    <lname>1850_CAM55_CLM50%BGC_CICE_POP2%ECO_RTM_SGLC_SWAV_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>B1850Cw</alias>  
-    <lname>1850_CAM55%WTSM_CLM50%BGC-CROP_CICE_POP2_MOSART_SGLC_SWAV</lname>
+    <lname>1850_CAM55%WTSM_CLM50%BGC_CICE_POP2%ECO_MOSART_SGLC_SWAV_BGC%BDRD</lname>
   </compset>
 
 
@@ -282,7 +277,7 @@
 
   <compset>
     <alias>ETEST</alias>
-    <lname>2000_CAM55_CLM50%CROP_CICE_DOCN%SOM_MOSART_SGLC_SWAV_TEST</lname>
+    <lname>2000_CAM55_CLM50_CICE_DOCN%SOM_MOSART_SGLC_SWAV_TEST</lname>
   </compset>
 
   <compset>

--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -4,16 +4,23 @@
     <grid name="f09_g16">
       <test name="ERI">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
+        <machine compiler="intel" testtype="prebeta" testmods="allactive/cesm2dev01">edison</machine>
       </test>
       <test name="PFS">
         <machine compiler="pgi " testtype="prebeta" testmods="allactive/default">bluewaters</machine>
         <machine compiler="intel" testtype="prealpha" testmods="allactive/default">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/default">yellowstone</machine>
+        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01">yellowstone</machine>
       </test>
       <test name="NOC">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
+      </test>
+      <test name="ERS">
+        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01io">yellowstone</machine>
+      </test>
+      <test name="SMS_Ld7">
+        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01io">yellowstone</machine>
       </test>
     </grid>
     <grid name="f45_g37">
@@ -117,19 +124,6 @@
     <grid name="f19_g16">
       <test name="ERS_Ld7">
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850G">
-    <grid name="f09_g16">
-      <test name="ERS">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01io">yellowstone</machine>
-      </test>
-      <test name="PFS">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01">yellowstone</machine>
-      </test>
-      <test name="SMS_Ld7">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01io">yellowstone</machine>
       </test>
     </grid>
   </compset>

--- a/share/csm_share/shr/shr_flux_mod.F90
+++ b/share/csm_share/shr/shr_flux_mod.F90
@@ -428,7 +428,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
                            tBulk, tSkin, tSkin_day, tSkin_night,           &
                            cSkin, cSkin_night, secs ,dt,                   &
                            duu10n,  ustar_sv   ,re_sv ,ssq_sv,             &
-                           missval    )
+                           missval, cold_start    )
 ! !USES:
 
    implicit none
@@ -484,8 +484,9 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    real(R8),intent(out)   :: cSkin_night (nMax) ! NEW
    integer(IN),intent(in) :: secs               ! NEW  elsapsed seconds in day (GMT)
    integer(IN),intent(in) :: dt                 ! NEW
+   logical ,intent(in)    :: cold_start         ! cold start flag
 
-   real(R8),intent(in) ,optional :: missval        ! masked value
+   real(R8),intent(in) ,optional :: missval     ! masked value
 
    !--- output arguments -------------------------------
    real(R8),intent(out)  ::  sen  (nMax) ! heat flux: sensible    (W/m^2)
@@ -610,7 +611,6 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    real(R8)    :: phid   
    real(R8)    :: spval
 
-
    !--- local functions --------------------------------
    real(R8)    :: qsat   ! function: the saturation humididty of air (kg/m^3)
    real(R8)    :: cdn    ! function: neutral drag coeff at 10m
@@ -678,9 +678,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
          ! use swpen and ocnsal from input argument
       endif
  
-!     tcraig, dec 2013, this should only occur on a cold startup.
-      if (nint(minval(nInc(:))) == 0 .and. &
-          nint(maxval(nInc(:))) == 0 ) then
+       if (cold_start) then
 !         if (s_loglev > 0) then
             write(s_logunit,F00) "Initialize diurnal cycle fields"
 !         end if


### PR DESCRIPTION
This corrects an error in the initialization logic in shr_flux_atmocn_diurnal.  A new argument, cold_start, has been added to the interface to indicate to the subroutine whether the interface should reset the flux fields.  This should only happen on initial runs without a restart file.  The original logic was not robust.

Test suite: ERP_Ln9.ne30_ne30.FC55CLUBB.yellowstone_intel.cam-outfrq9s
Test baseline: cesm1_5_alpha06g
Test namelist changes: none
Test status: bit for bit but fixes exact restart bug

Fixes: [CIME Github issue # ] atmocn flux diurnal restart bug

User interface changes?: none

Code review: none
