### PR TITLE
Esp compset description fix

### DIFF
--- a/components/stub_comps/sesp/cime_config/config_component.xml
+++ b/components/stub_comps/sesp/cime_config/config_component.xml
@@ -14,8 +14,8 @@
   </entry>
 
   <description>
+    <desc compset="_"> No ESP component  </desc>
     <desc compset="_SESP">Stub esp component</desc>
-    <desc > No ESP component in compset </desc>
   </description>
 
 </definitions_variables>

--- a/components/stub_comps/sesp/cime_config/config_component.xml
+++ b/components/stub_comps/sesp/cime_config/config_component.xml
@@ -2,9 +2,9 @@
 
 <?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
 
-<definitions_variables> 
+<definitions_variables>
 
-  <entry id="COMP_ESP"> 
+  <entry id="COMP_ESP">
     <type>char</type>
     <valid_values>sesp</valid_values>
     <default_value>sesp</default_value>
@@ -15,6 +15,7 @@
 
   <description>
     <desc compset="_SESP">Stub esp component</desc>
+    <desc > No ESP component in compset </desc>
   </description>
 
-</definitions_variables> 
+</definitions_variables>


### PR DESCRIPTION
Tested B1850 compset with and without SESP 

When the SESP component is used you will get 2 descriptions, we will need to fix this in a future tag.
