### PR TITLE
Wav clock offset fix

### DIFF
--- a/driver_cpl/shr/seq_timemgr_mod.F90
+++ b/driver_cpl/shr/seq_timemgr_mod.F90
@@ -812,6 +812,7 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
     offset(seq_timemgr_nclock_ice) = ice_cpl_offset
     offset(seq_timemgr_nclock_glc) = glc_cpl_offset
     offset(seq_timemgr_nclock_rof) = rof_cpl_offset
+    offset(seq_timemgr_nclock_wav) = wav_cpl_offset
     offset(seq_timemgr_nclock_esp) = esp_cpl_offset
 
     do n = 1,max_clocks


### PR DESCRIPTION
Fix wav clock offset in the driver.

Test suite:  Test B1850 and TG
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes: 

User interface changes?: 

Code review: 
