### PR TITLE
Fixed ESP errors found in prealpha testing

### DIFF
--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -2211,8 +2211,8 @@
 
   <entry id="NINST_ESP_LAYOUT">
     <type>char</type>
-    <valid_values>sequential</valid_values>
-    <default_value>sequential</default_value>
+    <valid_values>sequential,concurrent</valid_values>
+    <default_value>concurrent</default_value>
     <group>mach_pes_esp</group>
     <file>env_mach_pes.xml</file>
     <desc>Layout of external processing tool instances</desc>

--- a/driver_cpl/driver/cesm_comp_mod.F90
+++ b/driver_cpl/driver/cesm_comp_mod.F90
@@ -1558,9 +1558,6 @@ subroutine cesm_init()
       call shr_sys_abort(subname//' ERROR: rof_prognostic but num_inst_rof not num_inst_max')
    if (wav_prognostic .and. num_inst_wav /= num_inst_max) &
       call shr_sys_abort(subname//' ERROR: wav_prognostic but num_inst_wav not num_inst_max')
-   if (num_inst_esp /= 1) then
-      call shr_sys_abort(subname//' ERROR: num_inst_esp must be 1')
-    end if
 
    !----------------------------------------------------------
    !| Initialize attribute vectors for prep_c2C_init_avs routines and fractions

--- a/driver_cpl/shr/seq_timemgr_mod.F90
+++ b/driver_cpl/shr/seq_timemgr_mod.F90
@@ -143,6 +143,16 @@ module seq_timemgr_mod
       seq_timemgr_optIfdays0        = "ifdays0"   , &
       seq_timemgr_optEnd            = "end"     
 
+   integer(SHR_KIND_IN),private,parameter :: &
+      seq_timemgr_nclock_drv  = 1, &
+      seq_timemgr_nclock_atm  = 2, &
+      seq_timemgr_nclock_lnd  = 3, &
+      seq_timemgr_nclock_ocn  = 4, &
+      seq_timemgr_nclock_ice  = 5, &
+      seq_timemgr_nclock_glc  = 6, &
+      seq_timemgr_nclock_wav  = 7, &
+      seq_timemgr_nclock_rof  = 8, &
+      seq_timemgr_nclock_esp  = 9
    integer(SHR_KIND_IN),private,parameter :: max_clocks = 9
    character(len=*),public,parameter :: &
       seq_timemgr_clock_drv  = 'seq_timemgr_clock_drv' , & 
@@ -154,21 +164,29 @@ module seq_timemgr_mod
       seq_timemgr_clock_wav  = 'seq_timemgr_clock_wav' , &
       seq_timemgr_clock_rof  = 'seq_timemgr_clock_rof' , &
       seq_timemgr_clock_esp  = 'seq_timemgr_clock_esp' 
-   integer(SHR_KIND_IN),private,parameter :: &
-      seq_timemgr_nclock_drv  = 1, &
-      seq_timemgr_nclock_atm  = 2, &
-      seq_timemgr_nclock_lnd  = 3, &
-      seq_timemgr_nclock_ocn  = 4, &
-      seq_timemgr_nclock_ice  = 5, &
-      seq_timemgr_nclock_glc  = 6, &
-      seq_timemgr_nclock_wav  = 7, &
-      seq_timemgr_nclock_rof  = 8, &
-      seq_timemgr_nclock_esp  = 9
    character(len=8),private,parameter :: seq_timemgr_clocks(max_clocks) = &
       (/'drv     ','atm     ','lnd     ','ocn     ', &
         'ice     ','glc     ','wav     ','rof     ','esp     '/)
 
-   integer(SHR_KIND_IN),private,parameter :: max_alarms = 16
+   integer(SHR_KIND_IN),private,parameter :: &
+      seq_timemgr_nalarm_restart = 1, &
+      seq_timemgr_nalarm_run     = 2, &
+      seq_timemgr_nalarm_stop    = 3, &
+      seq_timemgr_nalarm_datestop= 4, &
+      seq_timemgr_nalarm_history = 5, &
+      seq_timemgr_nalarm_atmrun  = 6, &
+      seq_timemgr_nalarm_lndrun  = 7, &
+      seq_timemgr_nalarm_ocnrun  = 8, &
+      seq_timemgr_nalarm_icerun  = 9, &
+      seq_timemgr_nalarm_glcrun  =10, &
+      seq_timemgr_nalarm_ocnnext =11, &
+      seq_timemgr_nalarm_tprof   =12, &
+      seq_timemgr_nalarm_histavg =13, &
+      seq_timemgr_nalarm_rofrun  =14, &
+      seq_timemgr_nalarm_wavrun  =15, &
+      seq_timemgr_nalarm_esprun  =16, &
+      seq_timemgr_nalarm_barrier =17, &
+      max_alarms = seq_timemgr_nalarm_barrier
    character(len=*),public,parameter :: &
       seq_timemgr_alarm_restart = 'seq_timemgr_alarm_restart ', &
       seq_timemgr_alarm_run     = 'seq_timemgr_alarm_run     ', &
@@ -187,24 +205,6 @@ module seq_timemgr_mod
       seq_timemgr_alarm_wavrun  = 'seq_timemgr_alarm_wavrun  ', &
       seq_timemgr_alarm_esprun  = 'seq_timemgr_alarm_esprun  ', &
       seq_timemgr_alarm_barrier = 'seq_timemgr_alarm_barrier '
-   integer(SHR_KIND_IN),private,parameter :: &
-      seq_timemgr_nalarm_restart = 1, &
-      seq_timemgr_nalarm_run     = 2, &
-      seq_timemgr_nalarm_stop    = 3, &
-      seq_timemgr_nalarm_datestop= 4, &
-      seq_timemgr_nalarm_history = 5, &
-      seq_timemgr_nalarm_atmrun  = 6, &
-      seq_timemgr_nalarm_lndrun  = 7, &
-      seq_timemgr_nalarm_ocnrun  = 8, &
-      seq_timemgr_nalarm_icerun  = 9, &
-      seq_timemgr_nalarm_glcrun  =10, &
-      seq_timemgr_nalarm_ocnnext =11, &
-      seq_timemgr_nalarm_tprof   =12, &
-      seq_timemgr_nalarm_histavg =13, &
-      seq_timemgr_nalarm_rofrun  =14, &
-      seq_timemgr_nalarm_wavrun  =15, &
-      seq_timemgr_nalarm_esprun  =16, &
-      seq_timemgr_nalarm_barrier =17
 
    type EClock_pointer     ! needed for array of pointers
       type(ESMF_Clock),pointer :: EClock => null()

--- a/scripts/Testing/Testcases/ERP_build.csh
+++ b/scripts/Testing/Testcases/ERP_build.csh
@@ -42,32 +42,35 @@ cp -f env_build.xml    env_build.xml.1
 # Halve the number of tasks and threads and ROOTPE and build again,
 #-----------------------------------------------------
 
-set NTASKS_ATM  = `./xmlquery NTASKS_ATM	-value`
-set NTASKS_LND  = `./xmlquery NTASKS_LND	-value`
-set NTASKS_ROF  = `./xmlquery NTASKS_ROF	-value`
-set NTASKS_WAV  = `./xmlquery NTASKS_WAV	-value`
-set NTASKS_OCN  = `./xmlquery NTASKS_OCN	-value`
-set NTASKS_ICE  = `./xmlquery NTASKS_ICE	-value`
-set NTASKS_GLC  = `./xmlquery NTASKS_GLC	-value`
-set NTASKS_CPL  = `./xmlquery NTASKS_CPL	-value`
+set NTASKS_ATM  = `./xmlquery NTASKS_ATM        -value`
+set NTASKS_LND  = `./xmlquery NTASKS_LND        -value`
+set NTASKS_ROF  = `./xmlquery NTASKS_ROF        -value`
+set NTASKS_WAV  = `./xmlquery NTASKS_WAV        -value`
+set NTASKS_OCN  = `./xmlquery NTASKS_OCN        -value`
+set NTASKS_ICE  = `./xmlquery NTASKS_ICE        -value`
+set NTASKS_GLC  = `./xmlquery NTASKS_GLC        -value`
+set NTASKS_ESP  = `./xmlquery NTASKS_ESP        -value`
+set NTASKS_CPL  = `./xmlquery NTASKS_CPL        -value`
 
-set NTHRDS_ATM  = `./xmlquery NTHRDS_ATM	-value`
-set NTHRDS_LND  = `./xmlquery NTHRDS_LND	-value`
-set NTHRDS_ROF  = `./xmlquery NTHRDS_ROF	-value`
-set NTHRDS_WAV  = `./xmlquery NTHRDS_WAV	-value`
-set NTHRDS_OCN  = `./xmlquery NTHRDS_OCN	-value`
-set NTHRDS_ICE  = `./xmlquery NTHRDS_ICE	-value`
-set NTHRDS_GLC  = `./xmlquery NTHRDS_GLC	-value`
-set NTHRDS_CPL  = `./xmlquery NTHRDS_CPL	-value`
+set NTHRDS_ATM  = `./xmlquery NTHRDS_ATM        -value`
+set NTHRDS_LND  = `./xmlquery NTHRDS_LND        -value`
+set NTHRDS_ROF  = `./xmlquery NTHRDS_ROF        -value`
+set NTHRDS_WAV  = `./xmlquery NTHRDS_WAV        -value`
+set NTHRDS_OCN  = `./xmlquery NTHRDS_OCN        -value`
+set NTHRDS_ICE  = `./xmlquery NTHRDS_ICE        -value`
+set NTHRDS_GLC  = `./xmlquery NTHRDS_GLC        -value`
+set NTHRDS_ESP  = `./xmlquery NTHRDS_ESP        -value`
+set NTHRDS_CPL  = `./xmlquery NTHRDS_CPL        -value`
 
-set ROOTPE_ATM  = `./xmlquery ROOTPE_ATM	-value`
-set ROOTPE_LND  = `./xmlquery ROOTPE_LND	-value`
-set ROOTPE_ROF  = `./xmlquery ROOTPE_ROF	-value`
-set ROOTPE_WAV  = `./xmlquery ROOTPE_WAV	-value`
-set ROOTPE_OCN  = `./xmlquery ROOTPE_OCN	-value`
-set ROOTPE_ICE  = `./xmlquery ROOTPE_ICE	-value`
-set ROOTPE_GLC  = `./xmlquery ROOTPE_GLC	-value`
-set ROOTPE_CPL  = `./xmlquery ROOTPE_CPL	-value`
+set ROOTPE_ATM  = `./xmlquery ROOTPE_ATM        -value`
+set ROOTPE_LND  = `./xmlquery ROOTPE_LND        -value`
+set ROOTPE_ROF  = `./xmlquery ROOTPE_ROF        -value`
+set ROOTPE_WAV  = `./xmlquery ROOTPE_WAV        -value`
+set ROOTPE_OCN  = `./xmlquery ROOTPE_OCN        -value`
+set ROOTPE_ICE  = `./xmlquery ROOTPE_ICE        -value`
+set ROOTPE_GLC  = `./xmlquery ROOTPE_GLC        -value`
+set ROOTPE_ESP  = `./xmlquery ROOTPE_ESP        -value`
+set ROOTPE_CPL  = `./xmlquery ROOTPE_CPL        -value`
 
 if ( $NTHRDS_ATM > 1 || $NTHRDS_LND > 1 || $NTHRDS_ROF > 1 || $NTHRDS_WAV > 1 || $NTHRDS_OCN > 1 || $NTHRDS_ICE > 1 || $NTHRDS_GLC > 1 || $NTHRDS_CPL > 1 ) then
   ./xmlchange -file env_build.xml -id BUILD_THREADED  -val TRUE

--- a/scripts/Testing/Testcases/NOC_build.csh
+++ b/scripts/Testing/Testcases/NOC_build.csh
@@ -15,7 +15,7 @@ set EXEROOT     = `./xmlquery EXEROOT		-value`
 ./xmlchange -file env_mach_pes.xml -id NINST_OCN  -val 1
 set maxtasks = 0
 
-foreach comp (ATM LND ROF WAV ICE GLC)
+foreach comp (ATM LND ROF WAV ICE GLC ESP)
   ./xmlchange NINST_$comp=2
 
   set tasks = `./xmlquery NTASKS_$comp -value`

--- a/scripts/Testing/Testcases/PET_script
+++ b/scripts/Testing/Testcases/PET_script
@@ -92,6 +92,7 @@ echo "   no restarts are written" >>& $TESTSTATUS_LOG
 ./xmlchange -file env_mach_pes.xml -id NTHRDS_GLC -val 1
 ./xmlchange -file env_mach_pes.xml -id NTHRDS_OCN -val 1
 ./xmlchange -file env_mach_pes.xml -id NTHRDS_ICE -val 1
+./xmlchange -file env_mach_pes.xml -id NTHRDS_ESP -val 1
 ./xmlchange -file env_mach_pes.xml -id NTHRDS_CPL -val 1
 
 cp -f env_mach_pes.xml LockedFiles/env_mach_pes.xml

--- a/scripts/Testing/Testcases/SEQ_script
+++ b/scripts/Testing/Testcases/SEQ_script
@@ -77,6 +77,7 @@ echo "doing a second a ${STOP_N} ${STOP_OPTION} with all rootpes set to 0" >>& $
 ./xmlchange -file env_mach_pes.xml -id ROOTPE_GLC -val 0
 ./xmlchange -file env_mach_pes.xml -id ROOTPE_OCN -val 0
 ./xmlchange -file env_mach_pes.xml -id ROOTPE_ICE -val 0
+./xmlchange -file env_mach_pes.xml -id ROOTPE_ESP -val 0
 ./xmlchange -file env_mach_pes.xml -id ROOTPE_CPL -val 0
 
 cp -f env_mach_pes.xml LockedFiles/env_mach_pes.xml


### PR DESCRIPTION
- max_alarms needs to be incremented any time a new alarm is added. By
  rearranging the code, I made this more obvious to hopefully avoid a
  repeat omission.
- Took out requirement that NINST_ESP must be one.
- Correct layout of multiple instances of ESP to concurrent
- Make sure all test build scripts handle ESP configuration

Test suite: drv prealpha test, Build SMS_D.f19_f19.PC4.yellowstone_intel.cam-cam4_port, NCK_Ld5.f19_g16.BC5L45BGCRG.yellowstone_intel.allactive-cism-test_coupling, NCK_Ld1.f10_f10.ICRUCLM45.yellowstone_intel.clm-default, ERP_Ld3.f19_f19.FW5SC.yellowstone_intel.cam-outfrq3d.GC
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit

Fixes: #429, #430 

User interface changes?: No

Code review: NA
