### PR TITLE
Revert Intel compiler on Yellowstone

### DIFF
--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -1727,7 +1727,7 @@
 	<command name="load">all-python-libs</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/16.0.2</command>
+	<command name="load">intel/15.0.3</command>
 	<command name="load">mkl/11.1.2</command>
 	<command name="load">trilinos/11.10.2</command>
 	<command name="load">esmf</command>


### PR DESCRIPTION
Revert Intel compiler version on Yellowstone
Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes: [CIME Github issue #]

User interface changes?: 

Code review: 
