### PR TITLE
fix / update to st_archive to correctly check if interim restart file dupli…

### DIFF
--- a/cime_config/cesm/archive.xml
+++ b/cime_config/cesm/archive.xml
@@ -100,6 +100,10 @@
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
+      <file_extension regex_suffix=".rs1\..*">
+	<subdir>rest</subdir> 
+	<keep_last_in_rundir>true</keep_last_in_rundir>
+      </file_extension>
       <file_extension regex_suffix=".h\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
@@ -185,6 +189,10 @@
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
       <file_extension regex_suffix=".rs\..*">
+	<subdir>rest</subdir> 
+	<keep_last_in_rundir>true</keep_last_in_rundir>
+      </file_extension>
+      <file_extension regex_suffix=".rs1\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
@@ -298,6 +306,10 @@
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
+      <file_extension regex_suffix=".rs1\..*">
+	<subdir>rest</subdir> 
+	<keep_last_in_rundir>true</keep_last_in_rundir>
+      </file_extension>
       <file_extension regex_suffix=".h\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
@@ -335,6 +347,10 @@
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
       <file_extension regex_suffix=".rs\..*">
+	<subdir>rest</subdir> 
+	<keep_last_in_rundir>true</keep_last_in_rundir>
+      </file_extension>
+      <file_extension regex_suffix=".rs1\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
@@ -426,6 +442,10 @@
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
+      <file_extension regex_suffix=".rs1\..*">
+	<subdir>rest</subdir> 
+	<keep_last_in_rundir>true</keep_last_in_rundir>
+      </file_extension>
       <file_extension regex_suffix=".h\..*">      
 	<subdir>hist</subdir> 
 	<keep_last_in_rundir>false</keep_last_in_rundir>
@@ -489,6 +509,10 @@
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>
       <file_extension regex_suffix=".rs\..*">
+	<subdir>rest</subdir> 
+	<keep_last_in_rundir>true</keep_last_in_rundir>
+      </file_extension>
+      <file_extension regex_suffix=".rs1\..*">
 	<subdir>rest</subdir> 
 	<keep_last_in_rundir>true</keep_last_in_rundir>
       </file_extension>

--- a/scripts/Tools/st_archive
+++ b/scripts/Tools/st_archive
@@ -720,7 +720,7 @@ sub main
 # run the archive process
 	archiveProcess( $XMLin, $dname, \@runfiles );
 
-	if( uc($config{'DOUT_S_SAVE_INTERIM_RESTART_FILES'}) == 'TRUE' )
+	if( uc($config{'DOUT_S_SAVE_INTERIM_RESTART_FILES'}) eq 'TRUE' )
 	{
 # remove restart duplicate files from the comp/rest and rest/dname directories
 	    removeDups( $dname );

--- a/scripts/Tools/st_archive
+++ b/scripts/Tools/st_archive
@@ -661,7 +661,7 @@ sub removeDups
 	my @matchfiles  = File::Find::Rule->file->name($file)->in($config{'DOUT_S_ROOT'});
 
 	foreach my $matchfile (@matchfiles) {
-	    if( $matchfile =~ /\/rest\// && $matchfile ne $restfile && $matchfile !~ /\/hist\// ) {
+	    if( $matchfile =~ /\/rest\// && $matchfile ne $restfile && $matchfile !~ /\/hist\// && $matchfile !~ /rpointer/) {
 		$logger->debug("Dedebugng matchfile=$matchfile matches restfile=$restfile");
 		unlink( $matchfile );
 	    }


### PR DESCRIPTION
The st_archive was incorrectly removing duplicate rpointer files in the archive/$case/rest/[datename]
directories to do an incorrect string comparison in the perl code. Also updated the archive.xml
to match on rs1.\* suffices for the data models.

Test suite: A compset test with toggling of restart settings in order to debug
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes: #445

Code review:
