### PR TITLE
Addition of ice to ocean coupling fields Fioi_bcphi, Fioi_bcpho, Fioi_flxdst

### DIFF
--- a/driver_cpl/driver/seq_rest_mod.F90
+++ b/driver_cpl/driver/seq_rest_mod.F90
@@ -183,7 +183,7 @@ contains
         ocn_present=ocn_present,        &
         glc_present=glc_present,        &
         wav_present=wav_present,        &
-        esp_present=wav_present,        &
+        esp_present=esp_present,        &
         atm_prognostic=atm_prognostic,      &
         lnd_prognostic=lnd_prognostic,      &
         ice_prognostic=ice_prognostic,      &

--- a/driver_cpl/shr/seq_flds_mod.F90
+++ b/driver_cpl/shr/seq_flds_mod.F90
@@ -1365,6 +1365,33 @@ module seq_flds_mod
      attname  = 'Faxa_salt'
      call metadata_set(attname, longname, stdname, units)
 
+     ! Black Carbon hydrophilic deposition  
+     call seq_flds_add(i2x_fluxes,"Fioi_bcphi" )
+     call seq_flds_add(x2o_fluxes,"Fioi_bcphi"   )
+     longname = 'Hydrophylic black carbon deposition flux'
+     stdname  = 'deposition_flux_of_hydrophylic_black_carbon'
+     units    = 'kg m-2 s-1'
+     attname  = 'Fioi_bcphi'
+     call metadata_set(attname, longname, stdname, units)
+
+     ! Black Carbon hydrophobic deposition  
+     call seq_flds_add(i2x_fluxes,"Fioi_bcpho" )
+     call seq_flds_add(x2o_fluxes,"Fioi_bcpho"   )
+     longname = 'Hydrophobic black carbon deposition flux'
+     stdname  = 'deposition_flux_of_hydrophobic_black_carbon'
+     units    = 'kg m-2 s-1'
+     attname  = 'Fioi_bcpho'
+     call metadata_set(attname, longname, stdname, units)
+
+     ! Dust flux
+     call seq_flds_add(i2x_fluxes,"Fioi_flxdst")
+     call seq_flds_add(x2o_fluxes,"Fioi_flxdst")
+     longname = 'Dust flux'
+     stdname  = 'dust_flux'
+     units    = 'kg m-2 s-1'
+     attname  = 'Fioi_flxdst'
+     call metadata_set(attname, longname, stdname, units)
+
      ! Sea surface temperature
      call seq_flds_add(o2x_states,"So_t")
      call seq_flds_add(x2i_states,"So_t")    


### PR DESCRIPTION
These changes add 3 new coupling fields between ice and ocean for use in marbl.

Test suite: SMS.T62_g16.GECO.yellowstone_intel with marbl branch
Test baseline: none
Test namelist changes: none
Test status: bit for bit but adds some new coupling fields

Fixes: [CIME Github issue #]

User interface changes?:  none

Code review: none
