### PR TITLE
Fix broken compset aliases

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,23 @@
 ======================================================================
 
+Originator: fischer-ncar 
+Date: July 7, 2016 
+Tag: cime4.5.22
+Answer Changes: None
+Tests: 
+Dependencies:
+
+Brief Summary:  Fix broken compset names
+
+User interface changes: 
+
+Modified files: git diff --name-status
+
+M       cime_config/cesm/allactive/config_compsets.xml
+M       cime_config/cesm/allactive/testlist_allactive.xml
+
+======================================================================
+
 Originator: cacraigucar, fischer-ncar
 Date: July 7, 2016
 Tag: cime4.5.21

--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -233,6 +233,11 @@
   <!-- BG compsets -->
 
   <compset>
+    <alias>BC5L45BGCRG</alias>
+    <lname>2000_CAM5_CLM45%BGC_CICE_POP2_RTM_CISM1_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>BC5L45BGCR</alias>
     <lname>2000_CAM5_CLM45%BGC_CICE_POP2_RTM_SGLC_SWAV</lname>
   </compset>

--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -73,28 +73,28 @@
       </test>
     </grid>
   </compset>
-  <compset name="B1850C4L45BGCRBPRPWs">
+  <compset name="B1850C4L45BGCRBPRP">
     <grid name="f19_g16">
       <test name="ERS">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
       </test>
     </grid>
   </compset>
-  <compset name="B1850C4RCO2L40CNRWs">
+  <compset name="B1850C4RCO2L40CNR">
     <grid name="f19_g16">
       <test name="ERS_Ld7">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
       </test>
     </grid>
   </compset>
-  <compset name="B1850C5L40SPRWs">
+  <compset name="B1850C5L40SPR">
     <grid name="f19_g16">
       <test name="PET_PT">
         <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
       </test>
     </grid>
   </compset>
-  <compset name="B1850C5L45BGCRWs">
+  <compset name="B1850C5L45BGCR">
     <grid name="T31_g37">
       <test name="ERS_Ld5">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/cism/test_coupling">yellowstone</machine>
@@ -106,7 +106,7 @@
       </test>
     </grid>
   </compset>
-  <compset name="B1850C5L45BGCRG2Ws">
+  <compset name="B1850C5L45BGCRG2">
     <grid name="T31_g37_gl20">
       <test name="SMS_Ld5">
         <machine compiler="intel" testtype="prealpha" testmods="allactive/cism/test_coupling">yellowstone</machine>
@@ -114,7 +114,7 @@
       </test>
     </grid>
   </compset>
-  <compset name="B1850C5WCCML45CNRWs">
+  <compset name="B1850C5WCCML45CNR">
     <grid name="f19_g16">
       <test name="ERS_Ld7">
         <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>


### PR DESCRIPTION
Fix broken compset aliases in config_compsets.xml and
testlist_allactive.xml

Test suite: 
Test baseline: 
Test namelist changes:  Fix broken compset aliases
Test status: bit-for-bit

Fixes: [CIME Github issue #]

User interface changes?: 

Code review: 
