### PR TITLE
Compsets cime5.2.0 alpha.7

### DIFF
--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -73,16 +73,6 @@
   </compset>
 
   <compset>
-    <alias>BC4FCHML40CNR</alias>
-    <lname>2000_CAM40%FCHM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>BC4TMOZL40SPR</alias>
-    <lname>2000_CAM40%TMOZ_CLM40%SP_CICE_POP2_RTM_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
     <alias>B1850C5L40SPR</alias>
     <lname>1850_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_SWAV</lname>
   </compset>
@@ -122,22 +112,6 @@
     <lname>1850_CAM40%RCO2_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname>
   </compset>
 
-
-  <compset>
-    <alias>B1850C5WCCML45CNRWs</alias>
-    <lname>1850_CAM50%WCCM_CLM45%CN_CICE_POP2_RTM_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>B1850C5WCCML45CN</alias>
-    <lname>1850_CAM50%WCCM_CLM45%CN_CICE_POP2_MOSART_SGLC_SWAV</lname>
-  </compset>
-
-
-  <compset>
-    <alias>BC4WCBCL40CNR</alias>
-    <lname>2013_CAM40%WCBC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname>
-  </compset>
 
   <compset>
     <alias>B1850C4L40CNRBDRD</alias>
@@ -181,16 +155,6 @@
   <compset>
     <alias>BHISTC5L45BGC</alias>
     <lname>HIST_CAM50_CLM45%BGC_CICE_POP2_MOSART_SGLC_WW3</lname>
-  </compset>
-
-  <compset>
-    <alias>BHISTC4FCHML40CNRWs</alias>
-    <lname>HIST_CAM40%FCHM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>BHISTC4FCHML40CNR</alias>
-    <lname>HIST_CAM40%FCHM_CLM40%CN_CICE_POP2_RTM_SGLC_WW3</lname>
   </compset>
 
   <compset>

--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -125,6 +125,14 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
+  <test name="SMS_Ld5" grid="f09_g16" compset="B1850CwWs" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prebeta"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00 </option>
+    </options>
+  </test>
   <test name="ERS_Ld5" grid="T31_g37" compset="B1850C5L45BGCR" testmods="allactive/defaultio">
     <machines>
       <machine name="yellowstone" compiler="intel" category="prealpha"/>
@@ -162,30 +170,6 @@
   <test name="ERS_Ld7" grid="f19_g16" compset="B1850C4RCO2L40CNRWs" testmods="allactive/defaultio">
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:20 </option>
-    </options>
-  </test>
-  <test name="ERS_Ld7" grid="f19_g16" compset="B1850C5WCCML45CNRWs" testmods="allactive/defaultio">
-    <machines>
-      <machine name="yellowstone" compiler="intel" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:20 </option>
-    </options>
-  </test>
-  <test name="ERS_Ld7" grid="f19_g16" compset="BC4FCHML40CNR" testmods="allactive/defaultio">
-    <machines>
-      <machine name="yellowstone" compiler="intel" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:20 </option>
-    </options>
-  </test>
-  <test name="ERS_Ld7" grid="f45_g37" compset="BC4TMOZL40SPR" testmods="allactive/defaultio">
-    <machines>
-      <machine name="yellowstone" compiler="gnu" category="prebeta"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20 </option>

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -3342,45 +3342,46 @@
     <valid_values></valid_values>
     <default_value>379.000</default_value>
     <values>
-      <value compset="^1850"					>284.7</value>
-      <value compset="^HIST.+BGC%BPRP"				>284.7</value>
-      <value compset="^HIST_CAM4%FCHM"				>0.000001</value>
-      <value compset="^2000"					>367.0</value>
-      <value compset="^1850.+DATM%NYF"				>379.000</value>
-      <value compset="^1850.+DATM%NYF.*_POP2%ECO"		>284.7</value>
-      <value compset="^2000.+DATM%NYF"				>379.000</value>
-      <value compset="^2000.+DATM%IAF"				>379.000</value>
-      <value compset="^HIST.+DATM"				>367.0</value>
-      <value compset="^4804.+DATM"				>367.0</value>
-      <value compset="^RCP2.+DATM"				>367.0</value>
-      <value compset="^RCP4.+DATM"				>367.0</value>
-      <value compset="^RCP6.+DATM"				>367.0</value>
-      <value compset="^RCP8.+DATM"				>367.0</value>
-      <value compset="^2000.+XATM"				>379.000</value>
-      <value compset="^HIST.+CAM"				>0.000001</value>
-      <value compset="^5505.+CAM"				>0.000001</value>
-      <value compset="^RCP2.+CAM"				>0.000001</value>
-      <value compset="^RCP4.+CAM"				>0.000001</value>
-      <value compset="^RCP6.+CAM"				>0.000001</value>
-      <value compset="^RCP8.+CAM"				>0.000001</value>
-      <value compset="^2013.+CAM"				>0.000001</value>
-      <value compset="^GEOS.+CAM"				>0.000001</value>
-      <value compset="^AMIP.+CAM"				>0.000001</value>
-      <value compset="^AR95"					>368.9</value>
-      <value compset="^AR97"					>368.9</value>
-      <value compset="^2003"					>367.0</value>
+      <value compset="^1850"                     >284.7</value>
+      <value compset="^HIST.+BGC%BPRP"           >284.7</value>
+      <value compset="^HIST_CAM4%FCHM"           >0.000001</value>
+      <value compset="^2000"                     >367.0</value>
+      <value compset="^1850.+DATM%NYF"           >379.000</value>
+      <value compset="^1850.+DATM%NYF.*_POP2%ECO">284.7</value>
+      <value compset="^2000.+DATM%NYF"           >379.000</value>
+      <value compset="^2000.+DATM%IAF"           >379.000</value>
+      <value compset="^HIST.+DATM"               >367.0</value>
+      <value compset="^4804.+DATM"               >367.0</value>
+      <value compset="^RCP2.+DATM"               >367.0</value>
+      <value compset="^RCP4.+DATM"               >367.0</value>
+      <value compset="^RCP6.+DATM"               >367.0</value>
+      <value compset="^RCP8.+DATM"               >367.0</value>
+      <value compset="^2000.+XATM"               >379.000</value>
+      <value compset="^HIST.+CAM"                >0.000001</value>
+      <value compset="^5505.+CAM"                >0.000001</value>
+      <value compset="^RCP2.+CAM"                >0.000001</value>
+      <value compset="^RCP4.+CAM"                >0.000001</value>
+      <value compset="^RCP6.+CAM"                >0.000001</value>
+      <value compset="^RCP8.+CAM"                >0.000001</value>
+      <value compset="^2013.+CAM"                >0.000001</value>
+      <value compset="^SDYN.+CAM"                >0.000001</value>
+      <value compset="^AMIP.+CAM"                >0.000001</value>
+      <value compset="^AR95"                     >368.9</value>
+      <value compset="^AR97"                     >368.9</value>
+      <value compset="^2003"                     >367.0</value>
       <!-- Override values based on CAM (WACCM) chemistry -->
-      <value compset="CAM[45]%W"				>0.000001</value>
-      <value compset="CAM[45]%SSOA"				>0.000001</value>
+      <value compset="CAM[456]0%W"               >0.000001</value>
+      <value compset="CAM[456]0%SVBS"            >0.000001</value>
+      <value compset="CAM[456]0%TMOZ"            >0.000001</value>
       <!-- Mariana's fix to allow isotopes to get the proper CO2 value -->
-      <value compset="CAM..%WISOall"				>284.7</value>
-      <value compset="^2000.+CAM[45]%WCSC"			>368.9</value>
-      <value compset="^2000.+CAM[45]%MOZM"			>0.000001</value>
-      <value compset="^2000.+CAM[45]%MMOS"			>0.000001</value>
-      <value compset="^2000.+CAM[45]%TMOZ"			>0.000001</value>
-      <value compset="^2000.+CAM[45]%SMA3"			>0.000001</value>
-      <value compset="^2000.+CAM[45]%SMA7"			>0.000001</value>
-      <value compset="^2000.+CAM[45]%SSOA"			>0.000001</value>
+      <value compset="CAM..%WISOall"             >284.7</value>
+      <value compset="^2000.+CAM[45]%WCSC"       >368.9</value>
+      <value compset="^2000.+CAM[45]%MOZM"       >0.000001</value>
+      <value compset="^2000.+CAM[45]%MMOS"       >0.000001</value>
+      <value compset="^2000.+CAM[45]%TMOZ"       >0.000001</value>
+      <value compset="^2000.+CAM[45]%SMA3"       >0.000001</value>
+      <value compset="^2000.+CAM[45]%SMA7"       >0.000001</value>
+      <value compset="^2000.+CAM[45]%SSOA"       >0.000001</value>
     </values>
     <group>run_co2</group>
     <file>env_run.xml</file>
@@ -3620,7 +3621,7 @@
     <desc compset="RCP2_">RCP2.6 future scenario:</desc>
     <desc compset="2013_">RCP4.5 based scenario from 2013 (control for WACCM/CARMA nuclear winter study):</desc>
     <desc compset="9205_CAM">1992 to 2005 transient:</desc>
-    <desc compset="GEOS_CAM">GEOS5 meteorology: for stand-alone cam</desc>
+    <desc compset="SDYN_CAM">prescribed meteorology: for stand-alone cam</desc>
     <desc compset="AR95_CAM">ARM95 IOP: for stand-alone cam</desc>
     <desc compset="AR97_CAM">ARM97 IOP: for stand-alone cam</desc>
     <desc compset="HIST_CLM4[05]%CN">CLM transient land use:</desc>


### PR DESCRIPTION
Remove unsupported waccm compsets and set CCSM_CO2_PPMV correctly for waccm and cam-chem compsets

Test suite: aux_wcm
Test baseline: 
Test namelist changes: 
Test status: bit-for-bit

Fixes [CIME Github issue #]

User interface changes?: 

Code review: 
