### PR TITLE
Py regex kdr

### DIFF
--- a/config/cesm/config_archive.xml
+++ b/config/cesm/config_archive.xml
@@ -1,10 +1,10 @@
 <components version="2.0">
 
   <comp_archive_spec compname="cam" compclass="atm">
-    <rest_file_extension>\.[ri]\..*</rest_file_extension>
-    <rest_file_extension>\.rh\d\.*</rest_file_extension>
-    <rest_file_extension>\.rs\.*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$</hist_file_extension>
+    <rest_file_extension>[ri]</rest_file_extension>
+    <rest_file_extension>rh\d*</rest_file_extension>
+    <rest_file_extension>rs</rest_file_extension>
+    <hist_file_extension>[eh]</hist_file_extension>
     <rest_history_varname>nhfil</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.atm$NINST_STRING</rpointer_file>
@@ -13,7 +13,7 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="datm" compclass="atm">
-    <rest_file_extension>\.r.*</rest_file_extension>
+    <rest_file_extension>r</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.atm$NINST_STRING</rpointer_file>
@@ -22,9 +22,9 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="clm" compclass="lnd">
-    <rest_file_extension>\.[ri]\..*</rest_file_extension>
-    <rest_file_extension>\.rh.*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$</hist_file_extension>
+    <rest_file_extension>r</rest_file_extension>
+    <rest_file_extension>rh\d?</rest_file_extension>
+    <hist_file_extension>h\d*</hist_file_extension>
     <rest_history_varname>locfnh</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.lnd$NINST_STRING</rpointer_file>
@@ -33,7 +33,7 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="dlnd" compclass="lnd">
-    <rest_file_extension>\.r.*</rest_file_extension>
+    <rest_file_extension>r</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.lnd$NINST_STRING</rpointer_file>
@@ -42,8 +42,8 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="rtm" compclass="rof">
-    <rest_file_extension>\.r.*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$</hist_file_extension>
+    <rest_file_extension>r</rest_file_extension>
+    <hist_file_extension>h\d*</hist_file_extension>
     <rest_history_varname>locfnh</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.rof$NINST_STRING</rpointer_file>
@@ -52,8 +52,8 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="mosart" compclass="rof">
-    <rest_file_extension>\.r.*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$</hist_file_extension>
+    <rest_file_extension>r</rest_file_extension>
+    <hist_file_extension>h\d*</hist_file_extension>
     <rest_history_varname>locfnh</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.rof$NINST_STRING</rpointer_file>
@@ -63,8 +63,8 @@
 
 
   <comp_archive_spec compname="cice" compclass="ice">
-    <rest_file_extension>\.[ri].*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$</hist_file_extension>
+    <rest_file_extension>[ri]</rest_file_extension>
+    <hist_file_extension>h\d*</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.ice$NINST_STRING</rpointer_file>
@@ -74,8 +74,8 @@
 
 
   <comp_archive_spec compname="pop" compclass="ocn">
-    <rest_file_extension>\.r.*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$|\.d[dovt]\.</hist_file_extension>
+    <rest_file_extension>r</rest_file_extension>
+    <hist_file_extension>h\d*|d[dovt]\.</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.ocn$NINST_STRING.restart</rpointer_file>
@@ -92,40 +92,32 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="cism" compclass="glc">
-    <rest_file_extension>\.[ri]\..*</rest_file_extension>
-    <hist_file_extension>\.h\..*\.nc$</hist_file_extension>
-    <hist_file_extension>\.initial_hist\..*\.nc$</hist_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
-    <rpointer>
+    <rest_file_extension>[ri]</rest_file_extension>
+    <hist_file_extension>h\d*</hist_file_extension>
+    <hist_file_extension>initial_hist</hist_file_extension>
+      <rest_history_varname>unset</rest_history_varname>
+      <rpointer>
       <rpointer_file>rpointer.glc$NINST_STRING</rpointer_file>
       <rpointer_content>./$CASE.cism$NINST_STRING.r.$DATENAME.nc</rpointer_content>
     </rpointer>
   </comp_archive_spec>
 
   <comp_archive_spec compname="ww3" compclass="wav">
-    <rest_file_extension>\.r.*</rest_file_extension>
-    <hist_file_extension>\.hi\..*\.nc$</hist_file_extension>
+    <rest_file_extension>r</rest_file_extension>
+    <hist_file_extension>hi</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.wav$NINST_STRING</rpointer_file>
       <rpointer_content>unset</rpointer_content>
     </rpointer>
-  </comp_archive_spec>
-
-
-  <comp_archive_spec compclass="esp" compname="dart">
-    <rest_file_extension>inflate_restart.*</rest_file_extension>
-    <hist_file_extension>\.True_State.*</hist_file_extension>
-    <hist_file_extension>\.Prior_Diag.*</hist_file_extension>
-    <hist_file_extension>\.Posterior_Diag.*</hist_file_extension>
-    <hist_file_extension>\..+\.posterior*</hist_file_extension>
-    <hist_file_extension>\..+\.prior*</hist_file_extension>
-    <hist_file_extension>\..+$_obs_seq.*</hist_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
-    <rpointer>
-      <rpointer_file>rpointer.unset</rpointer_file>
-      <rpointer_content>unset</rpointer_content>
-    </rpointer>
-  </comp_archive_spec>
-
-</components>
+    </comp_archive_spec>
+    <comp_archive_spec compclass="esp" compname="dart">
+      <rest_file_extension>e\.\w+inf\w+</rest_file_extension>
+      <hist_file_extension>[ei]</hist_file_extension>
+      <rest_history_varname>unset</rest_history_varname>
+      <rpointer>
+        <rpointer_file>rpointer.unset</rpointer_file>
+        <rpointer_content>unset</rpointer_content>
+      </rpointer>
+    </comp_archive_spec>
+  </components>

--- a/config/config_headers.xml
+++ b/config/config_headers.xml
@@ -78,6 +78,19 @@
       To validate the env_archive.xml file using xmllint, run
       xmllint -schema $SRCROOT/cime/config/xml_schemas/env_archive.xsd env_archive.xml
       from the case root.
+      The patterns below are Python regular expressions.
+      The file names created from these patterns will add an optional digit
+      to them and will enclose them in a pair of '.'.
+      Some useful Python metacharacters are:
+         [] = any single character inside the brackets
+         \d = a digit = [0123456789] = [0-9]
+          ? = 0 or 1 of the previous character
+          * = 0 or more of the previous character (greedy!)
+          + = 1 or more of the previous character (greedy!)
+         \. = a period
+          . = any non-newline character
+      Use them carefully.  They're often confused with shell-type
+      wild card characters.
     </header>
   </file>
 

--- a/config/e3sm/config_archive.xml
+++ b/config/e3sm/config_archive.xml
@@ -44,7 +44,7 @@
   <comp_archive_spec compname="rtm" compclass="rof">
     <rest_file_extension>r</rest_file_extension>
     <hist_file_extension>h\d*</hist_file_extension>
-    <rest_history_varname>locfnh</rest_history_varname>
+    <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.rof$NINST_STRING</rpointer_file>
       <rpointer_content>$CASE.rtm$NINST_STRING.r.$DATENAME.nc</rpointer_content>
@@ -54,7 +54,7 @@
   <comp_archive_spec compname="mosart" compclass="rof">
     <rest_file_extension>r</rest_file_extension>
     <hist_file_extension>h\d*</hist_file_extension>
-    <rest_history_varname>locfnh</rest_history_varname>
+    <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.rof$NINST_STRING</rpointer_file>
       <rpointer_content>$CASE.mosart$NINST_STRING.r.$DATENAME.nc</rpointer_content>
@@ -118,8 +118,8 @@
     <hist_file_extension>hist</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
-      <rpointer_file>rpointer.ocn$NINST_STRING.tavg</rpointer_file>
-      <rpointer_content>./$CASE.pop$NINST_STRING.rh.$DATENAME.nc</rpointer_content>
+      <rpointer_file>rpointer.ocn$NINST_STRING</rpointer_file>
+      <rpointer_content>$MPAS_DATENAME</rpointer_content>
     </rpointer>
   </comp_archive_spec>
 
@@ -136,8 +136,8 @@
     <rest_file_extension>[ri]</rest_file_extension>
     <hist_file_extension>h\d*</hist_file_extension>
     <hist_file_extension>initial_hist</hist_file_extension>
-      <rest_history_varname>unset</rest_history_varname>
-      <rpointer>
+    <rest_history_varname>unset</rest_history_varname>
+    <rpointer>
       <rpointer_file>rpointer.glc$NINST_STRING</rpointer_file>
       <rpointer_content>./$CASE.cism$NINST_STRING.r.$DATENAME.nc</rpointer_content>
     </rpointer>
@@ -154,7 +154,7 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="ww3" compclass="wav">
-    <rest_file_extension>r</rest_file_extension>
+    <rest_file_extension>\..*</rest_file_extension>
     <hist_file_extension>hi</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>

--- a/config/e3sm/config_archive.xml
+++ b/config/e3sm/config_archive.xml
@@ -1,10 +1,10 @@
 <components version="2.0">
 
   <comp_archive_spec compname="cam" compclass="atm">
-    <rest_file_extension>\.[ri]\..*</rest_file_extension>
-     <rest_file_extension>\.rh\d\.*</rest_file_extension>
-     <rest_file_extension>\.rs\.*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$</hist_file_extension>
+    <rest_file_extension>[ri]</rest_file_extension>
+    <rest_file_extension>rh\d*</rest_file_extension>
+    <rest_file_extension>rs</rest_file_extension>
+    <hist_file_extension>[eh]</hist_file_extension>
     <rest_history_varname>nhfil</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.atm$NINST_STRING</rpointer_file>
@@ -13,7 +13,7 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="datm" compclass="atm">
-    <rest_file_extension>\.r.*</rest_file_extension>
+    <rest_file_extension>r</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.atm$NINST_STRING</rpointer_file>
@@ -22,9 +22,9 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="clm" compclass="lnd">
-    <rest_file_extension>\.[ri]\..*</rest_file_extension>
-    <rest_file_extension>\.rh.*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$</hist_file_extension>
+    <rest_file_extension>r</rest_file_extension>
+    <rest_file_extension>rh\d?</rest_file_extension>
+    <hist_file_extension>h\d*</hist_file_extension>
     <rest_history_varname>locfnh</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.lnd$NINST_STRING</rpointer_file>
@@ -33,7 +33,7 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="dlnd" compclass="lnd">
-    <rest_file_extension>\.r.*</rest_file_extension>
+    <rest_file_extension>r</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.lnd$NINST_STRING</rpointer_file>
@@ -42,9 +42,9 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="rtm" compclass="rof">
-    <rest_file_extension>\.r.*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$</hist_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
+    <rest_file_extension>r</rest_file_extension>
+    <hist_file_extension>h\d*</hist_file_extension>
+    <rest_history_varname>locfnh</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.rof$NINST_STRING</rpointer_file>
       <rpointer_content>$CASE.rtm$NINST_STRING.r.$DATENAME.nc</rpointer_content>
@@ -52,9 +52,9 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="mosart" compclass="rof">
-    <rest_file_extension>\.r.*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$</hist_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
+    <rest_file_extension>r</rest_file_extension>
+    <hist_file_extension>h\d*</hist_file_extension>
+    <rest_history_varname>locfnh</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.rof$NINST_STRING</rpointer_file>
       <rpointer_content>$CASE.mosart$NINST_STRING.r.$DATENAME.nc</rpointer_content>
@@ -62,7 +62,7 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="drof" compclass="rof">
-    <rest_file_extension>\.r.*</rest_file_extension>
+    <rest_file_extension>r</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.rof$NINST_STRING</rpointer_file>
@@ -71,8 +71,8 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="cice" compclass="ice">
-    <rest_file_extension>\.[ri].*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$</hist_file_extension>
+    <rest_file_extension>[ri]</rest_file_extension>
+    <hist_file_extension>h\d*</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.ice$NINST_STRING</rpointer_file>
@@ -81,8 +81,8 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="mpascice" compclass="ice">
-    <rest_file_extension>\.rst.*</rest_file_extension>
-    <hist_file_extension>\.hist.*\.*\.*\.nc</hist_file_extension>
+    <rest_file_extension>rst</rest_file_extension>
+    <hist_file_extension>hist</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.ice$NINST_STRING</rpointer_file>
@@ -91,7 +91,7 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="dice" compclass="ice">
-    <rest_file_extension>\.r.*</rest_file_extension>
+    <rest_file_extension>r</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.ice$NINST_STRING</rpointer_file>
@@ -100,31 +100,31 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="pop" compclass="ocn">
-    <rest_file_extension>\.r.*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$|\.d[dovt]\.</hist_file_extension>
+    <rest_file_extension>r</rest_file_extension>
+    <hist_file_extension>h\d*|d[dovt]</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
-      <rpointer_file>rpointer.ocn.restart$NINST_STRING</rpointer_file>
+      <rpointer_file>rpointer.ocn$NINST_STRING.restart</rpointer_file>
       <rpointer_content>./$CASE.pop$NINST_STRING.r.$DATENAME.nc,RESTART_FMT=nc</rpointer_content>
     </rpointer>
     <rpointer>
-      <rpointer_file>rpointer.ocn.ovf$NINST_STRING</rpointer_file>
+      <rpointer_file>rpointer.ocn$NINST_STRING.ovf</rpointer_file>
       <rpointer_content>./$CASE.pop$NINST_STRING.ro.$DATENAME</rpointer_content>
     </rpointer>
   </comp_archive_spec>
 
   <comp_archive_spec compname="mpaso" compclass="ocn">
-    <rest_file_extension>\.rst.*</rest_file_extension>
-    <hist_file_extension>\.hist.*\.*\.*\.nc</hist_file_extension>
+    <rest_file_extension>rst</rest_file_extension>
+    <hist_file_extension>hist</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
-      <rpointer_file>rpointer.ocn$NINST_STRING</rpointer_file>
-      <rpointer_content>$MPAS_DATENAME</rpointer_content>
+      <rpointer_file>rpointer.ocn$NINST_STRING.tavg</rpointer_file>
+      <rpointer_content>./$CASE.pop$NINST_STRING.rh.$DATENAME.nc</rpointer_content>
     </rpointer>
   </comp_archive_spec>
 
   <comp_archive_spec compname="docn" compclass="ocn">
-    <rest_file_extension>\.r.*</rest_file_extension>
+    <rest_file_extension>r</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.ocn$NINST_STRING</rpointer_file>
@@ -133,19 +133,19 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="cism" compclass="glc">
-    <rest_file_extension>\.[ri]\..*</rest_file_extension>
-    <hist_file_extension>\.h\..*\.nc$</hist_file_extension>
-    <hist_file_extension>\.initial_hist\..*\.nc$</hist_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
-    <rpointer>
+    <rest_file_extension>[ri]</rest_file_extension>
+    <hist_file_extension>h\d*</hist_file_extension>
+    <hist_file_extension>initial_hist</hist_file_extension>
+      <rest_history_varname>unset</rest_history_varname>
+      <rpointer>
       <rpointer_file>rpointer.glc$NINST_STRING</rpointer_file>
       <rpointer_content>./$CASE.cism$NINST_STRING.r.$DATENAME.nc</rpointer_content>
     </rpointer>
   </comp_archive_spec>
 
   <comp_archive_spec compname="mpasli" compclass="glc">
-    <rest_file_extension>\.rst.*</rest_file_extension>
-    <hist_file_extension>\.hist.*</hist_file_extension>
+    <rest_file_extension>rst</rest_file_extension>
+    <hist_file_extension>hist</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.glc$NINST_STRING</rpointer_file>
@@ -154,8 +154,8 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="ww3" compclass="wav">
-    <rest_file_extension>\.\..*</rest_file_extension>
-    <hist_file_extension>\.hi.*</hist_file_extension>
+    <rest_file_extension>r</rest_file_extension>
+    <hist_file_extension>hi</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.wav$NINST_STRING</rpointer_file>
@@ -164,7 +164,7 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="dwav" compclass="wav">
-    <rest_file_extension>\.r.*</rest_file_extension>
+    <rest_file_extension>r</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.wav$NINST_STRING</rpointer_file>
@@ -173,19 +173,14 @@
   </comp_archive_spec>
 
 
-  <comp_archive_spec compclass="esp" compname="dart">
-    <rest_file_extension>inflate_restart.*</rest_file_extension>
-    <hist_file_extension>\.True_State.*</hist_file_extension>
-    <hist_file_extension>\.Prior_Diag.*</hist_file_extension>
-    <hist_file_extension>\.Posterior_Diag.*</hist_file_extension>
-    <hist_file_extension>\..+\.posterior*</hist_file_extension>
-    <hist_file_extension>\..+\.prior*</hist_file_extension>
-    <hist_file_extension>\..+$_obs_seq.*</hist_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
-    <rpointer>
-      <rpointer_file>rpointer.unset</rpointer_file>
-      <rpointer_content>unset</rpointer_content>
-    </rpointer>
-  </comp_archive_spec>
-
-</components>
+    </comp_archive_spec>
+    <comp_archive_spec compclass="esp" compname="dart">
+      <rest_file_extension>e\.\w+inf\w+</rest_file_extension>
+      <hist_file_extension>[ei]</hist_file_extension>
+      <rest_history_varname>unset</rest_history_varname>
+      <rpointer>
+        <rpointer_file>rpointer.unset</rpointer_file>
+        <rpointer_content>unset</rpointer_content>
+      </rpointer>
+    </comp_archive_spec>
+  </components>

--- a/src/components/data_comps/datm/cime_config/config_archive.xml
+++ b/src/components/data_comps/datm/cime_config/config_archive.xml
@@ -1,6 +1,6 @@
 <components version="2.0">
   <comp_archive_spec compname="datm" compclass="atm">
-    <rest_file_extension>\.r.*</rest_file_extension>
+    <rest_file_extension>r</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.atm$NINST_STRING</rpointer_file>

--- a/src/components/data_comps/dice/cime_config/config_archive.xml
+++ b/src/components/data_comps/dice/cime_config/config_archive.xml
@@ -1,6 +1,6 @@
 <components version="2.0">
   <comp_archive_spec compname="dice" compclass="ice">
-    <rest_file_extension>\.r.*</rest_file_extension>
+    <rest_file_extension>r</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.ice$NINST_STRING</rpointer_file>

--- a/src/components/data_comps/dlnd/cime_config/config_archive.xml
+++ b/src/components/data_comps/dlnd/cime_config/config_archive.xml
@@ -1,6 +1,6 @@
 <components version="2.0">
   <comp_archive_spec compname="dlnd" compclass="lnd">
-    <rest_file_extension>\.r.*</rest_file_extension>
+    <rest_file_extension>r</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.lnd$NINST_STRING</rpointer_file>

--- a/src/components/data_comps/docn/cime_config/config_archive.xml
+++ b/src/components/data_comps/docn/cime_config/config_archive.xml
@@ -1,6 +1,6 @@
 <components version="2.0">
   <comp_archive_spec compname="docn" compclass="ocn">
-    <rest_file_extension>\.r.*</rest_file_extension>
+    <rest_file_extension>rs*\d*</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.ocn$NINST_STRING</rpointer_file>

--- a/src/components/data_comps/drof/cime_config/config_archive.xml
+++ b/src/components/data_comps/drof/cime_config/config_archive.xml
@@ -1,6 +1,6 @@
 <components version="2.0">
   <comp_archive_spec compname="drof" compclass="rof">
-    <rest_file_extension>\.r.*</rest_file_extension>
+    <rest_file_extension>r</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.rof$NINST_STRING</rpointer_file>

--- a/src/components/data_comps/dwav/cime_config/config_archive.xml
+++ b/src/components/data_comps/dwav/cime_config/config_archive.xml
@@ -1,6 +1,6 @@
 <components version="2.0">
   <comp_archive_spec compname="dwav" compclass="wav">
-    <rest_file_extension>\.r.*</rest_file_extension>
+    <rest_file_extension>r</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.wav$NINST_STRING</rpointer_file>

--- a/src/drivers/mct/cime_config/config_archive.xml
+++ b/src/drivers/mct/cime_config/config_archive.xml
@@ -1,7 +1,7 @@
 <components version="2.0">
   <comp_archive_spec compname="drv" compclass="cpl">
-    <rest_file_extension>\.r\..*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$</hist_file_extension>
+    <rest_file_extension>r</rest_file_extension>
+    <hist_file_extension>h\d*</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer$NINST_STRING.drv</rpointer_file>


### PR DESCRIPTION
Proposed changes to st_archive regular expressions, 
which accommodate DART files, reduce metacharacters 
in env_archive.xml, and make some regexes more selective 
or robust.  
Potential fix for #2334. 
I'm not sure that e3sm changes should be in this, 
but included them to be sure the regression test would work.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2334

User interface changes?: in env_archive.xml

Update gh-pages html (Y/N)?:

Code review: 
