### PR TITLE
lawrencium machine files

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -461,6 +461,32 @@
     </queues>
   </batch_system>
 
+  <batch_system MACH="lawrencium-lr3" type="slurm">
+    <batch_submit>sbatch</batch_submit>
+    <directives>
+      <directive>--qos=lr_normal</directive>
+      <directive>--partition=lr3</directive>
+      <directive>--account={{ project }}</directive>
+      <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
+    </directives>
+    <queues>
+      <queue walltimemin="00:00:00" walltimemax="72:00:00" nodemin="1" nodemax="64" default="true">lr3</queue>
+    </queues>
+  </batch_system>
+  
+  <batch_system MACH="lawrencium-lr2" type="slurm">
+    <batch_submit>sbatch</batch_submit>
+    <directives>
+       <directive>--qos=lr_normal</directive>
+       <directive>--partition=lr2</directive>
+       <directive>--account={{ project }}</directive>
+       <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
+    </directives>
+    <queues>
+      <queue walltimemin="00:00:00" walltimemax="72:00:00" nodemin="1" nodemax="64" default="true">lr2</queue>
+    </queues>
+  </batch_system>
+  
   <batch_system MACH="stampede" type="slurm" >
     <batch_submit>ssh stampede.tacc.utexas.edu cd $CASEROOT ; sbatch</batch_submit>
     <submit_args>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -1032,6 +1032,40 @@ using a fortran linker.
   </CMAKE_OPTS>
 </compiler>
 
+<compiler COMPILER="intel" MACH="lawrencium-lr3">
+  <CPPDEFS>
+    <append MODEL="gptl"> -DHAVE_VPRINTF -DHAVE_TIMES -DHAVE_GETTIMEOFDAY </append>
+  </CPPDEFS>
+  <SLIBS>
+    <append> -lnetcdff -lnetcdf -mkl </append>
+  </SLIBS>
+  <FFLAGS>
+    <append DEBUG="TRUE"> -ftrapuv </append>
+  </FFLAGS>
+  <CFLAGS>
+    <append DEBUG="TRUE"> -ftrapuv </append>
+  </CFLAGS>
+  <NETCDF_PATH>$ENV{NETCDF_DIR}</NETCDF_PATH>
+  <LAPACK_LIBDIR>/global/software/sl-6.x86_64/modules/intel/2016.1.150/lapack/3.6.0-intel/lib</LAPACK_LIBDIR>
+</compiler>
+
+<compiler COMPILER="intel" MACH="lawrencium-lr2">
+  <CPPDEFS>
+    <append MODEL="gptl"> -DHAVE_VPRINTF -DHAVE_TIMES -DHAVE_GETTIMEOFDAY </append>
+  </CPPDEFS>
+  <SLIBS>
+    <append> -lnetcdff -lnetcdf -mkl </append>
+  </SLIBS>
+  <FFLAGS>
+    <append DEBUG="TRUE"> -ftrapuv </append>
+  </FFLAGS>
+  <CFLAGS>
+    <append DEBUG="TRUE"> -ftrapuv </append>
+  </CFLAGS>
+  <NETCDF_PATH>$ENV{NETCDF_DIR}</NETCDF_PATH>
+  <LAPACK_LIBDIR>/global/software/sl-6.x86_64/modules/intel/2016.1.150/lapack/3.6.0-intel/lib</LAPACK_LIBDIR>
+</compiler>
+
 <compiler MACH="yellowstone" COMPILER="gnu">
   <LAPACK_LIBDIR> /glade/apps/opt/lib </LAPACK_LIBDIR>
   <SCC MPILIB="mpi-serial">gcc</SCC>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1094,6 +1094,118 @@
     </environment_variables>
   </machine>
 
+  <machine MACH="lawrencium-lr3">
+    <DESC>Lawrencium LR3 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
+    <NODENAME_REGEX>n00*</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>intel</COMPILERS>
+    <MPILIBS>openmpi,mpi-serial</MPILIBS>
+    <CIME_OUTPUT_ROOT>/global/scratch/$ENV{USER}</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/global/scratch/$ENV{USER}/cesm_input_datasets/</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/global/scratch/$ENV{USER}/cesm_input_datasets/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/cesm_archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>$CIME_OUTPUT_ROOT/cesm_baselines</BASELINE_ROOT>
+    <CCSM_CPRNC>/$CIME_OUTPUT_ROOT/cesm_tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>4</GMAKE_J>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>rgknox at lbl dot gov</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+    <mpirun mpilib="mpi-serial">
+      <executable></executable>
+    </mpirun>
+    <mpirun mpilib="default">
+      <executable>mpirun</executable>
+      <arguments>
+	<arg name="num_tasks">-np $TOTALPES</arg>
+	<arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE </arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
+      <init_path lang="csh">/etc/profile.d/modules.csh</init_path>
+      <init_path lang="perl">/usr/Modules/init/perl.pm</init_path>
+      <init_path lang="python">/usr/Modules/python.py</init_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <cmd_path lang="perl">/usr/Modules/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="python">/usr/Modules/bin/modulecmd python</cmd_path>
+      <modules>
+        <command name="purge"/>
+        <command name="load">cmake</command>
+        <command name="load">perl xml-libxml switch python/2.7</command>
+      </modules>
+      <modules compiler="intel">
+        <command name="load">intel/2016.4.072</command>
+        <command name="load">mkl</command>
+      </modules>
+      <modules compiler="intel" mpilib="mpi-serial">
+        <command name="load">netcdf/4.4.1.1-intel-s</command>
+      </modules>
+      <modules compiler="intel" mpilib="!mpi-serial">
+        <command name="load">openmpi</command>
+        <command name="load">netcdf/4.4.1.1-intel-p</command>
+      </modules>
+    </module_system>
+  </machine>
+  
+  <machine MACH="lawrencium-lr2">
+    <DESC>Lawrencium LR2 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
+    <NODENAME_REGEX>n00*</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>intel</COMPILERS>
+    <MPILIBS>openmpi,mpi-serial</MPILIBS>
+    <CIME_OUTPUT_ROOT>/global/scratch/$ENV{USER}</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/global/scratch/$ENV{USER}/cesm_input_datasets/</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/global/scratch/$ENV{USER}/cesm_input_datasets/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/cesm_archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>$CIME_OUTPUT_ROOT/cesm_baselines</BASELINE_ROOT>
+    <CCSM_CPRNC>/$CIME_OUTPUT_ROOT/cesm_tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>4</GMAKE_J>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>rgknox and gbisht at lbl dot gov</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>12</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>12</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+    <mpirun mpilib="mpi-serial">
+      <executable></executable>
+    </mpirun>
+    <mpirun mpilib="default">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks"> -np $TOTALPES</arg>
+        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
+      <init_path lang="csh">/etc/profile.d/modules.csh</init_path>
+      <init_path lang="perl">/usr/Modules/init/perl.pm</init_path>
+      <init_path lang="python">/usr/Modules/python.py</init_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <cmd_path lang="perl">/usr/Modules/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="python">/usr/Modules/bin/modulecmd python</cmd_path>
+      <modules>
+        <command name="purge"/>
+        <command name="load">cmake</command>
+        <command name="load">perl xml-libxml switch python/2.7</command>
+      </modules>
+      <modules compiler="intel">
+        <command name="load">intel/2016.4.072</command>
+        <command name="load">mkl</command>
+      </modules>
+      <modules compiler="intel" mpilib="mpi-serial">
+        <command name="load">netcdf/4.4.1.1-intel-s</command>
+      </modules>
+      <modules compiler="intel" mpilib="!mpi-serial">
+        <command name="load">openmpi</command>
+        <command name="load">netcdf/4.4.1.1-intel-p</command>
+      </modules>
+    </module_system>
+  </machine>
+
   <machine MACH="melvin">
     <DESC>Linux workstation for Jenkins testing</DESC>
     <NODENAME_REGEX>(melvin|watson)</NODENAME_REGEX>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1098,7 +1098,7 @@
     <DESC>Lawrencium LR3 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
-    <MPILIBS>openmpi,mpi-serial</MPILIBS>
+    <MPILIBS>openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>/global/scratch/$ENV{USER}</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/global/scratch/$ENV{USER}/cesm_input_datasets/</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/global/scratch/$ENV{USER}/cesm_input_datasets/atm/datm7</DIN_LOC_ROOT_CLMFORC>
@@ -1150,7 +1150,7 @@
     <DESC>Lawrencium LR2 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
-    <MPILIBS>openmpi,mpi-serial</MPILIBS>
+    <MPILIBS>openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>/global/scratch/$ENV{USER}</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/global/scratch/$ENV{USER}/cesm_input_datasets/</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/global/scratch/$ENV{USER}/cesm_input_datasets/atm/datm7</DIN_LOC_ROOT_CLMFORC>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1096,7 +1096,6 @@
 
   <machine MACH="lawrencium-lr3">
     <DESC>Lawrencium LR3 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
-    <NODENAME_REGEX>n00*</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
     <MPILIBS>openmpi,mpi-serial</MPILIBS>
@@ -1149,7 +1148,6 @@
   
   <machine MACH="lawrencium-lr2">
     <DESC>Lawrencium LR2 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
-    <NODENAME_REGEX>n00*</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
     <MPILIBS>openmpi,mpi-serial</MPILIBS>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1112,9 +1112,6 @@
     <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
-    </mpirun>
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
@@ -1168,9 +1165,6 @@
     <MAX_TASKS_PER_NODE>12</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>12</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
-    </mpirun>
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>

--- a/config/cesm/machines/config_pio.xml
+++ b/config/cesm/machines/config_pio.xml
@@ -45,6 +45,8 @@
     <values>
       <value>pnetcdf</value>
       <value mpilib="mpi-serial">netcdf</value>
+      <value mach="lawrencium-lr3">netcdf</value>
+      <value mach="lawrencium-lr2">netcdf</value>
     </values>
   </entry>
 

--- a/config/cesm/machines/config_pio.xml
+++ b/config/cesm/machines/config_pio.xml
@@ -45,8 +45,6 @@
     <values>
       <value>pnetcdf</value>
       <value mpilib="mpi-serial">netcdf</value>
-      <value mach="lawrencium-lr3">netcdf</value>
-      <value mach="lawrencium-lr2">netcdf</value>
     </values>
   </entry>
 


### PR DESCRIPTION
This set of changes adds lawrencium machine files to CIME cesm builds.

Test suite: Requests?  conducted 1x1br and f45 lnd simulations
Test baseline: 
Test namelist changes: none
Test status: no precedent on lawrencium machines, b4b all others

Fixes [CIME Github issue #]

User interface changes?: no

Update gh-pages html (Y/N)?: No, 

Code review: 
